### PR TITLE
fix(project): add validation if lb is taikun

### DIFF
--- a/taikun/helper.go
+++ b/taikun/helper.go
@@ -181,15 +181,6 @@ func getShowbackType(showbackType string) models.ShowbackType {
 	return 200
 }
 
-func getLoadBalancingSolution(octaviaEnabled bool, taikunLBEnabled bool) string {
-	if octaviaEnabled {
-		return "Octavia"
-	} else if taikunLBEnabled {
-		return "Taikun"
-	}
-	return "None"
-}
-
 func getUserRole(role string) models.UserRole {
 	if role == "User" {
 		return 400
@@ -198,10 +189,25 @@ func getUserRole(role string) models.UserRole {
 	return 200
 }
 
-func parseLoadBalancingSolution(loadBalancingSolution string) (bool, bool) {
-	if loadBalancingSolution == "Octavia" {
+const (
+	loadBalancerOctavia = "Octavia"
+	loadBalancerTaikun  = "Taikun"
+	loadBalancerNone    = "None"
+)
+
+func getLoadBalancingSolution(octaviaEnabled bool, taikunLBEnabled bool) string {
+	if octaviaEnabled {
+		return loadBalancerOctavia
+	} else if taikunLBEnabled {
+		return loadBalancerTaikun
+	}
+	return loadBalancerNone
+}
+
+func parseLoadBalancingSolution(loadBalancingSolution string) (octaviaEnabled bool, taikunLBEnabled bool) {
+	if loadBalancingSolution == loadBalancerOctavia {
 		return true, false
-	} else if loadBalancingSolution == "Taikun" {
+	} else if loadBalancingSolution == loadBalancerTaikun {
 		return false, true
 	}
 	return false, false
@@ -307,3 +313,9 @@ func getKubeconfigRoleID(role string) int32 {
 		return 4
 	}
 }
+
+const (
+	cloudTypeAWS       = "AWS"
+	cloudTypeAzure     = "Azure"
+	cloudTypeOpenStack = "OpenStack"
+)

--- a/taikun/resource_taikun_project.go
+++ b/taikun/resource_taikun_project.go
@@ -1222,23 +1222,20 @@ func resourceTaikunProjectValidateKubernetesProfileLB(data *schema.ResourceData,
 		if err != nil {
 			return err
 		}
-		if lbSolution == loadBalancerNone {
-			return nil
-		}
-
-		cloudCredentialID, _ := atoi32(data.Get("cloud_credential_id").(string))
-		cloudType, err := resourceTaikunProjectGetCloudType(cloudCredentialID, apiClient)
-		if err != nil {
-			return err
-		}
-		if cloudType != cloudTypeOpenStack {
-			return fmt.Errorf("If %s load balancer is enabled, cloud type should be OpenStack; is %s", lbSolution, cloudType)
-		}
-
 		if lbSolution == loadBalancerTaikun {
+			cloudCredentialID, _ := atoi32(data.Get("cloud_credential_id").(string))
+			cloudType, err := resourceTaikunProjectGetCloudType(cloudCredentialID, apiClient)
+			if err != nil {
+				return err
+			}
 			if _, taikunLBFlavorIsSet := data.GetOk("taikun_lb_flavor"); !taikunLBFlavorIsSet {
 				return fmt.Errorf("If Taikun load balancer is enabled, router_id_start_range, router_id_end_range and taikun_lb_flavor must be set")
 			}
+			if cloudType != cloudTypeOpenStack {
+				return fmt.Errorf("If Taikun load balancer is enabled, cloud type should be OpenStack; is %s", cloudType)
+			}
+		} else if _, taikunLBFlavorIsSet := data.GetOk("taikun_lb_flavor"); taikunLBFlavorIsSet {
+			return fmt.Errorf("If Taikun load balancer is not enabled, router_id_start_range, router_id_end_range and taikun_lb_flavor should not be set")
 		}
 	}
 	return nil


### PR DESCRIPTION
If project's kubernetes profile has Taikun as load balancer,
- check project's cloud type is OpenStack
- check taikun_lb_flavor, router_id_start_range and router_id_end_range are set

If project's kubernetes profile has Octavia or None as load balancer,
- check taikun_lb_flavor, router_id_start_range and router_id_end_range are _not_ set

Closes #134 