### PR TITLE
test: retry read in check destroy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 70
     concurrency: test-acc
-    continue-on-error: true
     steps:
 
       - name: Set up Go

--- a/taikun/data_source_taikun_access_profiles_test.go
+++ b/taikun/data_source_taikun_access_profiles_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceTaikunAccessProfiles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceTaikunAccessProfilesConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_access_profiles.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_access_profiles.all", "access_profiles.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_access_profiles.all", "access_profiles.0.dns_server.#"),
@@ -56,7 +56,7 @@ func TestAccDataSourceTaikunAccessProfilesWithFilter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccDataSourceTaikunAccessProfilesWithFilterConfig, organizationName, organizationFullName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_access_profiles.all", "access_profiles.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_access_profiles.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_access_profiles.all", "access_profiles.#"),

--- a/taikun/data_source_taikun_alerting_profiles_test.go
+++ b/taikun/data_source_taikun_alerting_profiles_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceTaikunAlertingProfiles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceTaikunAlertingProfilesConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_alerting_profiles.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_alerting_profiles.all", "alerting_profiles.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_alerting_profiles.all", "alerting_profiles.0.emails.#"),
@@ -59,7 +59,7 @@ func TestAccDataSourceTaikunAlertingProfilesWithFilter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccDataSourceTaikunAlertingProfilesWithFilterConfig, organizationName, organizationFullName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_alerting_profiles.all", "alerting_profiles.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_alerting_profiles.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_alerting_profiles.all", "alerting_profiles.#"),

--- a/taikun/data_source_taikun_backup_credentials_test.go
+++ b/taikun/data_source_taikun_backup_credentials_test.go
@@ -35,7 +35,7 @@ func TestAccDataSourceTaikunBackupCredentials(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_backup_credentials.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_backup_credentials.all", "backup_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_backup_credentials.all", "backup_credentials.0.created_by"),
@@ -94,7 +94,7 @@ func TestAccDataSourceTaikunBackupCredentialsWithFilter(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_backup_credentials.all", "backup_credentials.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_backup_credentials.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_backup_credentials.all", "backup_credentials.#"),

--- a/taikun/data_source_taikun_billing_credentials_test.go
+++ b/taikun/data_source_taikun_billing_credentials_test.go
@@ -37,7 +37,7 @@ func TestAccDataSourceTaikunBillingCredentials(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_billing_credentials.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_billing_credentials.all", "billing_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_billing_credentials.all", "billing_credentials.0.created_by"),
@@ -98,7 +98,7 @@ func TestAccDataSourceTaikunBillingCredentialsWithFilter(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_billing_credentials.all", "billing_credentials.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_billing_credentials.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_billing_credentials.all", "billing_credentials.#"),

--- a/taikun/data_source_taikun_billing_rules_test.go
+++ b/taikun/data_source_taikun_billing_rules_test.go
@@ -51,7 +51,7 @@ func TestAccDataSourceTaikunBillingRules(t *testing.T) {
 					os.Getenv("PROMETHEUS_USERNAME"),
 					billingRuleName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_billing_rules.all", "billing_rules.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_billing_rules.all", "billing_rules.0.created_by"),
 					resource.TestCheckResourceAttrSet("data.taikun_billing_rules.all", "billing_rules.0.id"),

--- a/taikun/data_source_taikun_cloud_credentials_aws_test.go
+++ b/taikun/data_source_taikun_cloud_credentials_aws_test.go
@@ -32,7 +32,7 @@ func TestAccDataSourceTaikunCloudCredentialsAWS(t *testing.T) {
 					cloudCredentialName,
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_cloud_credentials_aws.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_aws.all", "cloud_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_aws.all", "cloud_credentials.0.created_by"),
@@ -87,7 +87,7 @@ func TestAccDataSourceTaikunCloudCredentialsAWSWithFilter(t *testing.T) {
 					cloudCredentialName,
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_cloud_credentials_aws.all", "cloud_credentials.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_aws.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_aws.all", "cloud_credentials.#"),

--- a/taikun/data_source_taikun_cloud_credentials_azure_test.go
+++ b/taikun/data_source_taikun_cloud_credentials_azure_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceTaikunCloudCredentialsAzure(t *testing.T) {
 					os.Getenv("ARM_AVAILABILITY_ZONE"),
 					os.Getenv("ARM_LOCATION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_cloud_credentials_azure.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_azure.all", "cloud_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_azure.all", "cloud_credentials.0.created_by"),
@@ -92,7 +92,7 @@ func TestAccDataSourceTaikunCloudCredentialsAzureWithFilter(t *testing.T) {
 					os.Getenv("ARM_AVAILABILITY_ZONE"),
 					os.Getenv("ARM_LOCATION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_cloud_credentials_azure.all", "cloud_credentials.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_azure.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_azure.all", "cloud_credentials.#"),

--- a/taikun/data_source_taikun_cloud_credentials_openstack_test.go
+++ b/taikun/data_source_taikun_cloud_credentials_openstack_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceTaikunCloudCredentialsOpenStack(t *testing.T) {
 				Config: fmt.Sprintf(testAccDataSourceTaikunCloudCredentialsOpenStackConfig,
 					cloudCredentialName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_cloud_credentials_openstack.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_openstack.all", "cloud_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_openstack.all", "cloud_credentials.0.created_by"),
@@ -86,7 +86,7 @@ func TestAccDataSourceTaikunCloudCredentialsOpenStackWithFilter(t *testing.T) {
 					organizationFullName,
 					cloudCredentialName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_cloud_credentials_openstack.all", "cloud_credentials.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_openstack.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_cloud_credentials_openstack.all", "cloud_credentials.#"),

--- a/taikun/data_source_taikun_flavors_test.go
+++ b/taikun/data_source_taikun_flavors_test.go
@@ -40,7 +40,7 @@ func TestAccDataSourceTaikunFlavorsAWS(t *testing.T) {
 					cpu, cpu,
 					ram, ram,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_flavors.foo", "flavors.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_flavors.foo", "flavors.0.name"),
 					resource.TestCheckResourceAttr("data.taikun_flavors.foo", "flavors.0.cpu", fmt.Sprint(cpu)),
@@ -85,7 +85,7 @@ func TestAccDataSourceTaikunFlavorsAzure(t *testing.T) {
 					cpu, cpu,
 					ram, ram,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_flavors.foo", "flavors.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_flavors.foo", "flavors.0.name"),
 					resource.TestCheckResourceAttr("data.taikun_flavors.foo", "flavors.0.cpu", fmt.Sprint(cpu)),
@@ -126,7 +126,7 @@ func TestAccDataSourceTaikunFlavorsOpenStack(t *testing.T) {
 					cpu, cpu,
 					ram, ram,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_flavors.foo", "flavors.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_flavors.foo", "flavors.0.name"),
 					resource.TestCheckResourceAttr("data.taikun_flavors.foo", "flavors.0.cpu", fmt.Sprint(cpu)),

--- a/taikun/data_source_taikun_kubernetes_profiles_test.go
+++ b/taikun/data_source_taikun_kubernetes_profiles_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceTaikunKubernetesProfiles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceTaikunKubernetesProfilesConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_kubernetes_profiles.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_kubernetes_profiles.all", "kubernetes_profiles.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_kubernetes_profiles.all", "kubernetes_profiles.0.bastion_proxy"),
@@ -57,7 +57,7 @@ func TestAccDataSourceTaikunKubernetesProfilesWithFilter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccDataSourceTaikunKubernetesProfilesWithFilterConfig, organizationName, organizationFullName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_kubernetes_profiles.all", "kubernetes_profiles.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_kubernetes_profiles.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_kubernetes_profiles.all", "kubernetes_profiles.#"),

--- a/taikun/data_source_taikun_organization_test.go
+++ b/taikun/data_source_taikun_organization_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceTaikunOrganization(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceOrganizationConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_organization.foo", "discount_rate"),
 					resource.TestCheckResourceAttrSet("data.taikun_organization.foo", "name"),
 					resource.TestCheckResourceAttrSet("data.taikun_organization.foo", "full_name"),

--- a/taikun/data_source_taikun_organizations_test.go
+++ b/taikun/data_source_taikun_organizations_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceTaikunOrganizations(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceTaikunOrganizationsConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_organizations.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_organizations.all", "organizations.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_organizations.all", "organizations.0.discount_rate"),

--- a/taikun/data_source_taikun_projects_test.go
+++ b/taikun/data_source_taikun_projects_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceTaikunProjects(t *testing.T) {
 					cloudCredentialName,
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					projectName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_projects.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_projects.all", "projects.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_projects.all", "projects.0.name"),
@@ -99,7 +99,7 @@ func TestAccDataSourceTaikunProjectsWithFilter(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					projectCount,
 					projectName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_projects.foo", "projects.#", fmt.Sprint(projectCount)),
 				),
 			},

--- a/taikun/data_source_taikun_showback_credentials_test.go
+++ b/taikun/data_source_taikun_showback_credentials_test.go
@@ -37,7 +37,7 @@ func TestAccDataSourceTaikunShowbackCredentials(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_showback_credentials.all", "showback_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_credentials.all", "showback_credentials.0.created_by"),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_credentials.all", "showback_credentials.0.id"),
@@ -96,7 +96,7 @@ func TestAccDataSourceTaikunShowbackCredentialsWithFilter(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_showback_credentials.all", "showback_credentials.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_credentials.all", "showback_credentials.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_credentials.all", "showback_credentials.0.created_by"),

--- a/taikun/data_source_taikun_showback_rules_test.go
+++ b/taikun/data_source_taikun_showback_rules_test.go
@@ -53,7 +53,7 @@ func TestAccDataSourceTaikunShowbackRules(t *testing.T) {
 					projectLimit,
 					globalLimit,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.taikun_showback_rules.all", "showback_rules.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_rules.all", "showback_rules.0.id"),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_rules.all", "showback_rules.0.name"),
@@ -126,7 +126,7 @@ func TestAccDataSourceTaikunShowbackRulesWithFilter(t *testing.T) {
 					projectLimit,
 					globalLimit,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_showback_rules.all", "showback_rules.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_rules.all", "showback_rules.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_showback_rules.all", "showback_rules.0.id"),

--- a/taikun/data_source_taikun_slack_configurations_test.go
+++ b/taikun/data_source_taikun_slack_configurations_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceTaikunSlackConfigurations(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccDataSourceTaikunSlackConfigurationsConfig, slackConfigurationName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_slack_configurations.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_slack_configurations.all", "slack_configurations.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_slack_configurations.all", "slack_configurations.0.channel"),
@@ -87,7 +87,7 @@ func TestAccDataSourceTaikunSlackConfigurationsWithFilter(t *testing.T) {
 					organizationFullName,
 					slackConfigurationName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_slack_configurations.all", "slack_configurations.0.organization_name", organizationName),
 					resource.TestCheckResourceAttrSet("data.taikun_slack_configurations.all", "id"),
 					resource.TestCheckResourceAttrSet("data.taikun_slack_configurations.all", "slack_configurations.#"),

--- a/taikun/data_source_taikun_users.go
+++ b/taikun/data_source_taikun_users.go
@@ -63,7 +63,7 @@ func dataSourceTaikunUsersRead(_ context.Context, data *schema.ResourceData, met
 		params = params.WithOffset(&offset)
 	}
 
-	userList := make([]map[string]interface{}, len(rawUserList), len(rawUserList))
+	userList := make([]map[string]interface{}, len(rawUserList))
 	for i, rawUser := range rawUserList {
 		userList[i] = flattenTaikunUser(rawUser)
 	}

--- a/taikun/data_source_taikun_users_test.go
+++ b/taikun/data_source_taikun_users_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceTaikunUsers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceTaikunUsersConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_users.all", "id", "all"),
 					resource.TestCheckResourceAttrSet("data.taikun_users.all", "users.#"),
 					resource.TestCheckResourceAttrSet("data.taikun_users.all", "users.0.id"),
@@ -87,7 +87,7 @@ func TestAccDataSourceTaikunUsersWithFilter(t *testing.T) {
 					role,
 					displayName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.taikun_users.all", "users.0.user_name", userName),
 					resource.TestCheckResourceAttr("data.taikun_users.all", "users.0.role", role),
 					resource.TestCheckResourceAttr("data.taikun_users.all", "users.0.email", email),

--- a/taikun/resource_taikun_access_profile.go
+++ b/taikun/resource_taikun_access_profile.go
@@ -2,7 +2,6 @@ package taikun
 
 import (
 	"context"
-
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -240,6 +239,9 @@ func resourceTaikunAccessProfileUpdate(ctx context.Context, data *schema.Resourc
 	apiClient := meta.(*apiClient)
 
 	id, err := atoi32(data.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	if data.HasChange("lock") {
 		lockBody := models.AccessProfilesLockManagementCommand{

--- a/taikun/resource_taikun_access_profile_test.go
+++ b/taikun/resource_taikun_access_profile_test.go
@@ -94,7 +94,7 @@ func TestAccResourceTaikunAccessProfile(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunAccessProfileConfig, firstName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAccessProfileExists,
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "lock", "false"),
@@ -130,7 +130,7 @@ func TestAccResourceTaikunAccessProfileRenameAndLock(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunAccessProfileConfig, firstName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAccessProfileExists,
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "lock", "false"),
@@ -148,7 +148,7 @@ func TestAccResourceTaikunAccessProfileRenameAndLock(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunAccessProfileConfig, secondName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAccessProfileExists,
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "name", secondName),
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "lock", "true"),
@@ -205,7 +205,7 @@ func TestAccResourceTaikunAccessProfileUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunAccessProfileConfig, firstName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAccessProfileExists,
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "lock", "false"),
@@ -223,7 +223,7 @@ func TestAccResourceTaikunAccessProfileUpdate(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunAccessProfileConfigUpdate, secondName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAccessProfileExists,
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "name", secondName),
 					resource.TestCheckResourceAttr("taikun_access_profile.foo", "lock", "false"),

--- a/taikun/resource_taikun_access_profile_test.go
+++ b/taikun/resource_taikun_access_profile_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -271,7 +272,7 @@ func testAccCheckTaikunAccessProfileDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := access_profiles.NewAccessProfilesListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_access_profile_test.go
+++ b/taikun/resource_taikun_access_profile_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -270,12 +271,24 @@ func testAccCheckTaikunAccessProfileDestroy(state *terraform.State) error {
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := access_profiles.NewAccessProfilesListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := access_profiles.NewAccessProfilesListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.AccessProfiles.AccessProfilesList(params, client)
-		if err == nil && response.Payload.TotalCount != 0 {
-			return fmt.Errorf("access profile still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.AccessProfiles.AccessProfilesList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCount != 0 {
+				return resource.RetryableError(errors.New("access profile still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("access profile still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_alerting_profile_test.go
+++ b/taikun/resource_taikun_alerting_profile_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -383,7 +384,7 @@ func testAccCheckTaikunAlertingProfileDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := alerting_profiles.NewAlertingProfilesListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_alerting_profile_test.go
+++ b/taikun/resource_taikun_alerting_profile_test.go
@@ -161,7 +161,7 @@ func TestAccResourceTaikunAlertingProfile(t *testing.T) {
 					emails,
 					webhooks,
 					integrations),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAlertingProfileExists,
 					resource.TestCheckResourceAttrSet("taikun_alerting_profile.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_alerting_profile.foo", "slack_configuration_name", slackConfigName),
@@ -218,7 +218,7 @@ func TestAccResourceTaikunAlertingProfileModify(t *testing.T) {
 					emails,
 					webhooks,
 					integrations),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAlertingProfileExists,
 					resource.TestCheckResourceAttrSet("taikun_alerting_profile.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_alerting_profile.foo", "slack_configuration_name", slackConfigName),
@@ -241,7 +241,7 @@ func TestAccResourceTaikunAlertingProfileModify(t *testing.T) {
 					newEmails,
 					newWebhooks,
 					integrations),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAlertingProfileExists,
 					resource.TestCheckResourceAttrSet("taikun_alerting_profile.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_alerting_profile.foo", "slack_configuration_name", slackConfigName),
@@ -313,7 +313,7 @@ integration {
 					emails,
 					webhooks,
 					integrations),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAlertingProfileExists,
 					resource.TestCheckResourceAttrSet("taikun_alerting_profile.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_alerting_profile.foo", "slack_configuration_name", slackConfigName),
@@ -338,7 +338,7 @@ integration {
 					emails,
 					webhooks,
 					newIntegrations),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunAlertingProfileExists,
 					resource.TestCheckResourceAttrSet("taikun_alerting_profile.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_alerting_profile.foo", "slack_configuration_name", slackConfigName),

--- a/taikun/resource_taikun_backup_credential_test.go
+++ b/taikun/resource_taikun_backup_credential_test.go
@@ -81,7 +81,7 @@ func TestAccResourceTaikunBackupCredential(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBackupCredentialExists,
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "name", backupCredentialName),
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "s3_access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -113,7 +113,7 @@ func TestAccResourceTaikunBackupCredentialLock(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBackupCredentialExists,
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "name", backupCredentialName),
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "s3_access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -133,7 +133,7 @@ func TestAccResourceTaikunBackupCredentialLock(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBackupCredentialExists,
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "name", backupCredentialName),
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "s3_access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -166,7 +166,7 @@ func TestAccResourceTaikunBackupCredentialRename(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBackupCredentialExists,
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "name", backupCredentialName),
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "s3_access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -186,7 +186,7 @@ func TestAccResourceTaikunBackupCredentialRename(t *testing.T) {
 					os.Getenv("S3_ENDPOINT"),
 					os.Getenv("S3_REGION"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBackupCredentialExists,
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "name", newBackupCredentialName),
 					resource.TestCheckResourceAttr("taikun_backup_credential.foo", "s3_access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),

--- a/taikun/resource_taikun_backup_credential_test.go
+++ b/taikun/resource_taikun_backup_credential_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -231,7 +232,7 @@ func testAccCheckTaikunBackupCredentialDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := s3_credentials.NewS3CredentialsListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_billing_credential_test.go
+++ b/taikun/resource_taikun_billing_credential_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -159,12 +160,24 @@ func testAccCheckTaikunBillingCredentialDestroy(state *terraform.State) error {
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := ops_credentials.NewOpsCredentialsListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := ops_credentials.NewOpsCredentialsListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.OpsCredentials.OpsCredentialsList(params, client)
-		if err == nil && response.Payload.TotalCount != 0 {
-			return fmt.Errorf("billing credential still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.OpsCredentials.OpsCredentialsList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCount != 0 {
+				return resource.RetryableError(errors.New("billing credential still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("billing credential still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_billing_credential_test.go
+++ b/taikun/resource_taikun_billing_credential_test.go
@@ -77,7 +77,7 @@ func TestAccResourceTaikunBillingCredential(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunBillingCredentialConfig, firstName, false, os.Getenv("PROMETHEUS_PASSWORD"), os.Getenv("PROMETHEUS_URL"), os.Getenv("PROMETHEUS_USERNAME")),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingCredentialExists,
 					resource.TestCheckResourceAttr("taikun_billing_credential.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_billing_credential.foo", "lock", "false"),
@@ -106,7 +106,7 @@ func TestAccResourceTaikunBillingCredentialLock(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunBillingCredentialConfig, firstName, false, os.Getenv("PROMETHEUS_PASSWORD"), os.Getenv("PROMETHEUS_URL"), os.Getenv("PROMETHEUS_USERNAME")),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingCredentialExists,
 					resource.TestCheckResourceAttr("taikun_billing_credential.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_billing_credential.foo", "lock", "false"),
@@ -118,7 +118,7 @@ func TestAccResourceTaikunBillingCredentialLock(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunBillingCredentialConfig, firstName, true, os.Getenv("PROMETHEUS_PASSWORD"), os.Getenv("PROMETHEUS_URL"), os.Getenv("PROMETHEUS_USERNAME")),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingCredentialExists,
 					resource.TestCheckResourceAttr("taikun_billing_credential.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_billing_credential.foo", "lock", "true"),

--- a/taikun/resource_taikun_billing_credential_test.go
+++ b/taikun/resource_taikun_billing_credential_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -160,7 +161,7 @@ func testAccCheckTaikunBillingCredentialDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := ops_credentials.NewOpsCredentialsListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_billing_rule_test.go
+++ b/taikun/resource_taikun_billing_rule_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -273,7 +274,7 @@ func testAccCheckTaikunBillingRuleDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := prometheus.NewPrometheusListOfRulesParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_billing_rule_test.go
+++ b/taikun/resource_taikun_billing_rule_test.go
@@ -95,7 +95,7 @@ func TestAccResourceTaikunBillingRule(t *testing.T) {
 					os.Getenv("PROMETHEUS_USERNAME"),
 					ruleName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingRuleExists,
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "name", ruleName),
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "metric_name", "coredns_forward_request_duration_seconds"),
@@ -131,7 +131,7 @@ func TestAccResourceTaikunBillingRuleRename(t *testing.T) {
 					os.Getenv("PROMETHEUS_USERNAME"),
 					ruleName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingRuleExists,
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "name", ruleName),
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "metric_name", "coredns_forward_request_duration_seconds"),
@@ -148,7 +148,7 @@ func TestAccResourceTaikunBillingRuleRename(t *testing.T) {
 					os.Getenv("PROMETHEUS_USERNAME"),
 					ruleNameNew,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingRuleExists,
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "name", ruleNameNew),
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "metric_name", "coredns_forward_request_duration_seconds"),
@@ -213,7 +213,7 @@ func TestAccResourceTaikunBillingRuleUpdateLabels(t *testing.T) {
 					os.Getenv("PROMETHEUS_USERNAME"),
 					ruleName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingRuleExists,
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "name", ruleName),
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "metric_name", "coredns_forward_request_duration_seconds"),
@@ -231,7 +231,7 @@ func TestAccResourceTaikunBillingRuleUpdateLabels(t *testing.T) {
 					os.Getenv("PROMETHEUS_USERNAME"),
 					ruleName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunBillingRuleExists,
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "name", ruleName),
 					resource.TestCheckResourceAttr("taikun_billing_rule.foo", "metric_name", "coredns_forward_request_duration_seconds"),

--- a/taikun/resource_taikun_cloud_credential_aws_test.go
+++ b/taikun/resource_taikun_cloud_credential_aws_test.go
@@ -79,7 +79,7 @@ func TestAccResourceTaikunCloudCredentialAWS(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAWSExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -110,7 +110,7 @@ func TestAccResourceTaikunCloudCredentialAWSLock(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAWSExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -129,7 +129,7 @@ func TestAccResourceTaikunCloudCredentialAWSLock(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					true,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAWSExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -161,7 +161,7 @@ func TestAccResourceTaikunCloudCredentialAWSRename(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAWSExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),
@@ -180,7 +180,7 @@ func TestAccResourceTaikunCloudCredentialAWSRename(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAWSExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "name", newCloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_aws.foo", "access_key_id", os.Getenv("AWS_ACCESS_KEY_ID")),

--- a/taikun/resource_taikun_cloud_credential_aws_test.go
+++ b/taikun/resource_taikun_cloud_credential_aws_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -224,12 +225,24 @@ func testAccCheckTaikunCloudCredentialAWSDestroy(state *terraform.State) error {
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.CloudCredentials.CloudCredentialsDashboardList(params, client)
-		if err == nil && response.Payload.TotalCountAws != 0 {
-			return fmt.Errorf("aws cloud credential still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.CloudCredentials.CloudCredentialsDashboardList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCountAws != 0 {
+				return resource.RetryableError(errors.New("aws cloud credential still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("aws cloud credential still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_cloud_credential_aws_test.go
+++ b/taikun/resource_taikun_cloud_credential_aws_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -225,7 +226,7 @@ func testAccCheckTaikunCloudCredentialAWSDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_cloud_credential_azure_test.go
+++ b/taikun/resource_taikun_cloud_credential_azure_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -240,12 +241,24 @@ func testAccCheckTaikunCloudCredentialAzureDestroy(state *terraform.State) error
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.CloudCredentials.CloudCredentialsDashboardList(params, client)
-		if err == nil && response.Payload.TotalCountAzure != 0 {
-			return fmt.Errorf("azure cloud credential still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.CloudCredentials.CloudCredentialsDashboardList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCountAzure != 0 {
+				return resource.RetryableError(errors.New("azure cloud credential still exists ()"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("azure cloud credential still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_cloud_credential_azure_test.go
+++ b/taikun/resource_taikun_cloud_credential_azure_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -241,7 +242,7 @@ func testAccCheckTaikunCloudCredentialAzureDestroy(state *terraform.State) error
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_cloud_credential_azure_test.go
+++ b/taikun/resource_taikun_cloud_credential_azure_test.go
@@ -81,7 +81,7 @@ func TestAccResourceTaikunCloudCredentialAzure(t *testing.T) {
 					os.Getenv("ARM_LOCATION"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAzureExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "client_id", os.Getenv("ARM_CLIENT_ID")),
@@ -115,7 +115,7 @@ func TestAccResourceTaikunCloudCredentialAzureLock(t *testing.T) {
 					os.Getenv("ARM_LOCATION"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAzureExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "client_id", os.Getenv("ARM_CLIENT_ID")),
@@ -137,7 +137,7 @@ func TestAccResourceTaikunCloudCredentialAzureLock(t *testing.T) {
 					os.Getenv("ARM_LOCATION"),
 					true,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAzureExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "client_id", os.Getenv("ARM_CLIENT_ID")),
@@ -172,7 +172,7 @@ func TestAccResourceTaikunCloudCredentialAzureRename(t *testing.T) {
 					os.Getenv("ARM_LOCATION"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAzureExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "client_id", os.Getenv("ARM_CLIENT_ID")),
@@ -194,7 +194,7 @@ func TestAccResourceTaikunCloudCredentialAzureRename(t *testing.T) {
 					os.Getenv("ARM_LOCATION"),
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialAzureExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "name", newCloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_azure.foo", "client_id", os.Getenv("ARM_CLIENT_ID")),

--- a/taikun/resource_taikun_cloud_credential_openstack_test.go
+++ b/taikun/resource_taikun_cloud_credential_openstack_test.go
@@ -77,7 +77,7 @@ func TestAccResourceTaikunCloudCredentialOpenStack(t *testing.T) {
 					cloudCredentialName,
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialOpenStackExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "user", os.Getenv("OS_USERNAME")),
@@ -111,7 +111,7 @@ func TestAccResourceTaikunCloudCredentialOpenStackLock(t *testing.T) {
 					cloudCredentialName,
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialOpenStackExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "user", os.Getenv("OS_USERNAME")),
@@ -133,7 +133,7 @@ func TestAccResourceTaikunCloudCredentialOpenStackLock(t *testing.T) {
 					cloudCredentialName,
 					true,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialOpenStackExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "user", os.Getenv("OS_USERNAME")),
@@ -168,7 +168,7 @@ func TestAccResourceTaikunCloudCredentialOpenStackRename(t *testing.T) {
 					cloudCredentialName,
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialOpenStackExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "name", cloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "user", os.Getenv("OS_USERNAME")),
@@ -190,7 +190,7 @@ func TestAccResourceTaikunCloudCredentialOpenStackRename(t *testing.T) {
 					newCloudCredentialName,
 					false,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunCloudCredentialOpenStackExists,
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "name", newCloudCredentialName),
 					resource.TestCheckResourceAttr("taikun_cloud_credential_openstack.foo", "user", os.Getenv("OS_USERNAME")),

--- a/taikun/resource_taikun_cloud_credential_openstack_test.go
+++ b/taikun/resource_taikun_cloud_credential_openstack_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -239,7 +240,7 @@ func testAccCheckTaikunCloudCredentialOpenStackDestroy(state *terraform.State) e
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_cloud_credential_openstack_test.go
+++ b/taikun/resource_taikun_cloud_credential_openstack_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -238,12 +239,24 @@ func testAccCheckTaikunCloudCredentialOpenStackDestroy(state *terraform.State) e
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := cloud_credentials.NewCloudCredentialsDashboardListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.CloudCredentials.CloudCredentialsDashboardList(params, client)
-		if err == nil && response.Payload.TotalCountOpenstack != 0 {
-			return fmt.Errorf("openstack cloud credential still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.CloudCredentials.CloudCredentialsDashboardList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCountOpenstack != 0 {
+				return resource.RetryableError(errors.New("openstack cloud credential still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("openstack cloud credential still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_kubernetes_profile_test.go
+++ b/taikun/resource_taikun_kubernetes_profile_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -158,7 +159,7 @@ func testAccCheckTaikunKubernetesProfileDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := kubernetes_profiles.NewKubernetesProfilesListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_kubernetes_profile_test.go
+++ b/taikun/resource_taikun_kubernetes_profile_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -157,12 +158,24 @@ func testAccCheckTaikunKubernetesProfileDestroy(state *terraform.State) error {
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := kubernetes_profiles.NewKubernetesProfilesListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := kubernetes_profiles.NewKubernetesProfilesListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.KubernetesProfiles.KubernetesProfilesList(params, client)
-		if err == nil && response.Payload.TotalCount != 0 {
-			return fmt.Errorf("kubernetes profile still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.KubernetesProfiles.KubernetesProfilesList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCount != 0 {
+				return resource.RetryableError(errors.New("kubernetes profile still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("kubernetes profile still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_kubernetes_profile_test.go
+++ b/taikun/resource_taikun_kubernetes_profile_test.go
@@ -72,7 +72,7 @@ func TestAccResourceTaikunKubernetesProfile(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunKubernetesProfileConfig, firstName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunKubernetesProfileExists,
 					resource.TestCheckResourceAttr("taikun_kubernetes_profile.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_kubernetes_profile.foo", "lock", "false"),
@@ -102,7 +102,7 @@ func TestAccResourceTaikunKubernetesProfileLock(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunKubernetesProfileConfig, firstName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunKubernetesProfileExists,
 					resource.TestCheckResourceAttr("taikun_kubernetes_profile.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_kubernetes_profile.foo", "lock", "false"),
@@ -115,7 +115,7 @@ func TestAccResourceTaikunKubernetesProfileLock(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunKubernetesProfileConfig, firstName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunKubernetesProfileExists,
 					resource.TestCheckResourceAttr("taikun_kubernetes_profile.foo", "name", firstName),
 					resource.TestCheckResourceAttr("taikun_kubernetes_profile.foo", "lock", "true"),

--- a/taikun/resource_taikun_organization_billing_rule_attachment_test.go
+++ b/taikun/resource_taikun_organization_billing_rule_attachment_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -134,7 +135,7 @@ func testAccCheckTaikunOrganizationBillingRuleAttachmentDestroy(state *terraform
 			return err
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			params := prometheus.NewPrometheusListOfRulesParams().WithV(ApiVersion).WithID(&billingRuleId)
 			response, err := apiClient.client.Prometheus.PrometheusListOfRules(params, apiClient)
 			if err != nil {

--- a/taikun/resource_taikun_organization_billing_rule_attachment_test.go
+++ b/taikun/resource_taikun_organization_billing_rule_attachment_test.go
@@ -73,7 +73,7 @@ func TestAccResourceTaikunOrganizationBillingRuleAttachment(t *testing.T) {
 					fullOrgName,
 					globalDiscountRate,
 					ruleDiscountRate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunOrganizationBillingRuleAttachmentExists,
 					resource.TestCheckResourceAttrSet("taikun_organization_billing_rule_attachment.foo", "billing_rule_id"),
 					resource.TestCheckResourceAttrSet("taikun_organization_billing_rule_attachment.foo", "organization_id"),

--- a/taikun/resource_taikun_organization_billing_rule_attachment_test.go
+++ b/taikun/resource_taikun_organization_billing_rule_attachment_test.go
@@ -141,8 +141,8 @@ func testAccCheckTaikunOrganizationBillingRuleAttachmentDestroy(state *terraform
 			if err != nil {
 				return resource.NonRetryableError(err)
 			}
-			if len(response.Payload.Data) == 0 {
-				return resource.NonRetryableError(errors.New(fmt.Sprintf("billing rule with ID %d not found", billingRuleId)))
+			if len(response.Payload.Data) != 1 {
+				return nil
 			}
 
 			rawBillingRule := response.GetPayload().Data[0]

--- a/taikun/resource_taikun_organization_test.go
+++ b/taikun/resource_taikun_organization_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -259,12 +260,24 @@ func testAccCheckTaikunOrganizationDestroy(state *terraform.State) error {
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := organizations.NewOrganizationsListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := organizations.NewOrganizationsListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := apiClient.client.Organizations.OrganizationsList(params, apiClient)
-		if err == nil && response.Payload.TotalCount != 0 {
-			return fmt.Errorf("organization still exists (id = %s)", rs.Primary.ID)
+			response, err := apiClient.client.Organizations.OrganizationsList(params, apiClient)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCount != 0 {
+				return resource.RetryableError(errors.New("organization still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("organization still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_organization_test.go
+++ b/taikun/resource_taikun_organization_test.go
@@ -112,7 +112,7 @@ func TestAccResourceTaikunOrganization(t *testing.T) {
 					country,
 					isLocked,
 					letManagersChangeSubscription),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunOrganizationExists,
 					resource.TestCheckResourceAttr("taikun_organization.foo", "name", fmt.Sprint(name)),
 					resource.TestCheckResourceAttr("taikun_organization.foo", "full_name", fmt.Sprint(fullName)),
@@ -182,7 +182,7 @@ func TestAccResourceTaikunOrganizationUpdate(t *testing.T) {
 					country,
 					isLocked,
 					letManagersChangeSubscription),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunOrganizationExists,
 					resource.TestCheckResourceAttr("taikun_organization.foo", "name", fmt.Sprint(name)),
 					resource.TestCheckResourceAttr("taikun_organization.foo", "full_name", fmt.Sprint(fullName)),
@@ -212,7 +212,7 @@ func TestAccResourceTaikunOrganizationUpdate(t *testing.T) {
 					newCountry,
 					newIsLocked,
 					newLetManagersChangeSubscription),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunOrganizationExists,
 					resource.TestCheckResourceAttr("taikun_organization.foo", "name", fmt.Sprint(newName)),
 					resource.TestCheckResourceAttr("taikun_organization.foo", "full_name", fmt.Sprint(newFullName)),

--- a/taikun/resource_taikun_organization_test.go
+++ b/taikun/resource_taikun_organization_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -260,7 +261,7 @@ func testAccCheckTaikunOrganizationDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := organizations.NewOrganizationsListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_project_test.go
+++ b/taikun/resource_taikun_project_test.go
@@ -1051,7 +1051,7 @@ func testAccCheckTaikunProjectDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := projects.NewProjectsListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_project_test.go
+++ b/taikun/resource_taikun_project_test.go
@@ -130,7 +130,7 @@ func TestAccResourceTaikunProject(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(enableMonitoring)),
@@ -172,7 +172,7 @@ func TestAccResourceTaikunProjectExtendLifetime(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(enableMonitoring)),
@@ -192,7 +192,7 @@ func TestAccResourceTaikunProjectExtendLifetime(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					newExpirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(enableMonitoring)),
@@ -229,7 +229,7 @@ func TestAccResourceTaikunProjectToggleMonitoring(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(enableMonitoring)),
@@ -249,7 +249,7 @@ func TestAccResourceTaikunProjectToggleMonitoring(t *testing.T) {
 					enableAutoUpgrade,
 					disableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(disableMonitoring)),
@@ -269,7 +269,7 @@ func TestAccResourceTaikunProjectToggleMonitoring(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(enableMonitoring)),
@@ -386,7 +386,7 @@ func TestAccResourceTaikunProjectModifyAlertingProfile(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "alerting_profile_name", alertingProfileName),
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
@@ -413,7 +413,7 @@ func TestAccResourceTaikunProjectModifyAlertingProfile(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "alerting_profile_name", newAlertingProfileName),
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
@@ -452,7 +452,7 @@ func TestAccResourceTaikunProjectDetachAlertingProfile(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
 					resource.TestCheckResourceAttr("taikun_project.foo", "monitoring", fmt.Sprint(enableMonitoring)),
@@ -474,7 +474,7 @@ func TestAccResourceTaikunProjectDetachAlertingProfile(t *testing.T) {
 					enableAutoUpgrade,
 					enableMonitoring,
 					expirationDate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "alerting_profile_id", ""),
 					resource.TestCheckResourceAttr("taikun_project.foo", "auto_upgrade", fmt.Sprint(enableAutoUpgrade)),
@@ -543,7 +543,7 @@ func TestAccResourceTaikunProjectToggleBackup(t *testing.T) {
 					projectName,
 					"backup_credential_id = resource.taikun_backup_credential.foo.id",
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -568,7 +568,7 @@ func TestAccResourceTaikunProjectToggleBackup(t *testing.T) {
 					projectName,
 					"backup_credential_id = resource.taikun_backup_credential.foo2.id",
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -593,7 +593,7 @@ func TestAccResourceTaikunProjectToggleBackup(t *testing.T) {
 					projectName,
 					"",
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -618,7 +618,7 @@ func TestAccResourceTaikunProjectToggleBackup(t *testing.T) {
 					projectName,
 					"backup_credential_id = resource.taikun_backup_credential.foo.id",
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -659,7 +659,7 @@ func TestAccResourceTaikunProjectModifyFlavors(t *testing.T) {
 	projectName := randomTestName()
 	cpuCount := 2
 	newCpuCount := 8
-	checkFunc := resource.ComposeTestCheckFunc(
+	checkFunc := resource.ComposeAggregateTestCheckFunc(
 		testAccCheckTaikunProjectExists,
 		resource.TestCheckResourceAttr("taikun_project.foo", "name", projectName),
 		resource.TestCheckResourceAttrSet("taikun_project.foo", "access_profile_id"),
@@ -725,7 +725,7 @@ func TestAccResourceTaikunProjectQuota(t *testing.T) {
 					quota_disk_size = 200
 					`,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -749,7 +749,7 @@ func TestAccResourceTaikunProjectQuota(t *testing.T) {
 					quota_ram_size = 200
 					`,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -770,7 +770,7 @@ func TestAccResourceTaikunProjectQuota(t *testing.T) {
 					projectName,
 					"",
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -796,7 +796,7 @@ func TestAccResourceTaikunProjectQuota(t *testing.T) {
 					quota_ram_size = 201
 					`,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "auto_upgrade"),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "monitoring"),
@@ -846,7 +846,7 @@ func TestAccResourceTaikunProjectToggleLock(t *testing.T) {
 					projectName,
 					locked,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "name", projectName),
 					resource.TestCheckResourceAttr("taikun_project.foo", "lock", fmt.Sprint(locked)),
@@ -865,7 +865,7 @@ func TestAccResourceTaikunProjectToggleLock(t *testing.T) {
 					projectName,
 					unlocked,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "name", projectName),
 					resource.TestCheckResourceAttr("taikun_project.foo", "lock", fmt.Sprint(unlocked)),
@@ -884,7 +884,7 @@ func TestAccResourceTaikunProjectToggleLock(t *testing.T) {
 					projectName,
 					locked,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "name", projectName),
 					resource.TestCheckResourceAttr("taikun_project.foo", "lock", fmt.Sprint(locked)),
@@ -999,7 +999,7 @@ func TestAccResourceTaikunProjectMinimal(t *testing.T) {
 					cloudCredentialName,
 					projectName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectExists,
 					resource.TestCheckResourceAttr("taikun_project.foo", "name", projectName),
 					resource.TestCheckResourceAttrSet("taikun_project.foo", "access_profile_id"),

--- a/taikun/resource_taikun_project_user_attachment_test.go
+++ b/taikun/resource_taikun_project_user_attachment_test.go
@@ -121,7 +121,7 @@ func testAccCheckTaikunProjectUserAttachmentDestroy(state *terraform.State) erro
 				return resource.NonRetryableError(err)
 			}
 			if response.Payload.TotalCount != 1 {
-				return resource.NonRetryableError(errors.New(fmt.Sprintf("user with ID %s not found", userId)))
+				return nil
 			}
 
 			rawUser := response.GetPayload().Data[0]

--- a/taikun/resource_taikun_project_user_attachment_test.go
+++ b/taikun/resource_taikun_project_user_attachment_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -114,7 +115,7 @@ func testAccCheckTaikunProjectUserAttachmentDestroy(state *terraform.State) erro
 			return err
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			params := users.NewUsersListParams().WithV(ApiVersion).WithID(&userId)
 			response, err := apiClient.client.Users.UsersList(params, apiClient)
 			if err != nil {

--- a/taikun/resource_taikun_project_user_attachment_test.go
+++ b/taikun/resource_taikun_project_user_attachment_test.go
@@ -54,7 +54,7 @@ func TestAccResourceTaikunProjectUserAttachment(t *testing.T) {
 					os.Getenv("AWS_AVAILABILITY_ZONE"),
 					projectName,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunProjectUserAttachmentExists,
 					resource.TestCheckResourceAttrSet("taikun_project_user_attachment.foo", "project_id"),
 					resource.TestCheckResourceAttr("taikun_project_user_attachment.foo", "project_name", projectName),

--- a/taikun/resource_taikun_showback_credential_test.go
+++ b/taikun/resource_taikun_showback_credential_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -177,7 +178,7 @@ func testAccCheckTaikunShowbackCredentialDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := showback.NewShowbackCredentialsListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_showback_credential_test.go
+++ b/taikun/resource_taikun_showback_credential_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -176,12 +177,24 @@ func testAccCheckTaikunShowbackCredentialDestroy(state *terraform.State) error {
 			continue
 		}
 
-		id, _ := atoi32(rs.Primary.ID)
-		params := showback.NewShowbackCredentialsListParams().WithV(ApiVersion).WithID(&id)
+		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+			id, _ := atoi32(rs.Primary.ID)
+			params := showback.NewShowbackCredentialsListParams().WithV(ApiVersion).WithID(&id)
 
-		response, err := client.client.Showback.ShowbackCredentialsList(params, client)
-		if err == nil && response.Payload.TotalCount != 0 {
-			return fmt.Errorf("showback credential still exists (id = %s)", rs.Primary.ID)
+			response, err := client.client.Showback.ShowbackCredentialsList(params, client)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+			if response.Payload.TotalCount != 0 {
+				return resource.RetryableError(errors.New("showback credential still exists"))
+			}
+			return nil
+		})
+		if timedOut(retryErr) {
+			return errors.New("showback credential still exists (timed out)")
+		}
+		if retryErr != nil {
+			return retryErr
 		}
 	}
 

--- a/taikun/resource_taikun_showback_credential_test.go
+++ b/taikun/resource_taikun_showback_credential_test.go
@@ -82,7 +82,7 @@ func TestAccResourceTaikunShowbackCredential(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackCredentialExists,
 					resource.TestCheckResourceAttr("taikun_showback_credential.foo", "name", showbackCredentialName),
 					resource.TestCheckResourceAttr("taikun_showback_credential.foo", "lock", "false"),
@@ -117,7 +117,7 @@ func TestAccResourceTaikunShowbackCredentialLock(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackCredentialExists,
 					resource.TestCheckResourceAttr("taikun_showback_credential.foo", "name", showbackCredentialName),
 					resource.TestCheckResourceAttr("taikun_showback_credential.foo", "lock", "false"),
@@ -135,7 +135,7 @@ func TestAccResourceTaikunShowbackCredentialLock(t *testing.T) {
 					os.Getenv("PROMETHEUS_URL"),
 					os.Getenv("PROMETHEUS_USERNAME"),
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackCredentialExists,
 					resource.TestCheckResourceAttr("taikun_showback_credential.foo", "name", showbackCredentialName),
 					resource.TestCheckResourceAttr("taikun_showback_credential.foo", "lock", "true"),

--- a/taikun/resource_taikun_showback_rule_test.go
+++ b/taikun/resource_taikun_showback_rule_test.go
@@ -98,7 +98,7 @@ func TestAccResourceTaikunShowbackRule(t *testing.T) {
 					kind,
 					projectLimit,
 					globalLimit),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackRuleExists,
 					resource.TestCheckResourceAttr("taikun_showback_rule.foo", "name", name),
 					resource.TestCheckResourceAttr("taikun_showback_rule.foo", "metric_name", metricName),
@@ -152,7 +152,7 @@ func TestAccResourceTaikunShowbackRuleUpdate(t *testing.T) {
 					projectLimit,
 					globalLimit,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackRuleExists,
 					resource.TestCheckResourceAttrSet("taikun_showback_rule.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_showback_rule.foo", "name", name),
@@ -176,7 +176,7 @@ func TestAccResourceTaikunShowbackRuleUpdate(t *testing.T) {
 					newProjectLimit,
 					newGlobalLimit,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackRuleExists,
 					resource.TestCheckResourceAttrSet("taikun_showback_rule.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_showback_rule.foo", "name", newName),
@@ -248,7 +248,7 @@ func TestAccResourceTaikunShowbackRuleWithCredentials(t *testing.T) {
 					projectLimit,
 					globalLimit,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunShowbackRuleExists,
 					resource.TestCheckResourceAttrSet("taikun_showback_rule.foo", "id"),
 					resource.TestCheckResourceAttr("taikun_showback_rule.foo", "name", name),

--- a/taikun/resource_taikun_showback_rule_test.go
+++ b/taikun/resource_taikun_showback_rule_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -299,7 +300,7 @@ func testAccCheckTaikunShowbackRuleDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := showback.NewShowbackRulesListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_slack_configuration_test.go
+++ b/taikun/resource_taikun_slack_configuration_test.go
@@ -80,7 +80,7 @@ func TestAccResourceTaikunSlackConfiguration(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunSlackConfigurationConfig, name, url, channel, slackConfigType),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunSlackConfigurationExists,
 					resource.TestCheckResourceAttr("taikun_slack_configuration.foo", "channel", channel),
 					resource.TestCheckResourceAttrSet("taikun_slack_configuration.foo", "id"),
@@ -117,7 +117,7 @@ func TestAccResourceTaikunSlackConfigurationModify(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunSlackConfigurationConfig, name, url, channel, slackConfigType),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunSlackConfigurationExists,
 					resource.TestCheckResourceAttr("taikun_slack_configuration.foo", "channel", channel),
 					resource.TestCheckResourceAttrSet("taikun_slack_configuration.foo", "id"),
@@ -130,7 +130,7 @@ func TestAccResourceTaikunSlackConfigurationModify(t *testing.T) {
 			},
 			{
 				Config: fmt.Sprintf(testAccResourceTaikunSlackConfigurationConfig, newName, newUrl, newChannel, newSlackConfigType),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunSlackConfigurationExists,
 					resource.TestCheckResourceAttr("taikun_slack_configuration.foo", "channel", newChannel),
 					resource.TestCheckResourceAttrSet("taikun_slack_configuration.foo", "id"),

--- a/taikun/resource_taikun_slack_configuration_test.go
+++ b/taikun/resource_taikun_slack_configuration_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -173,7 +174,7 @@ func testAccCheckTaikunSlackConfigurationDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			id, _ := atoi32(rs.Primary.ID)
 			params := slack.NewSlackListParams().WithV(ApiVersion).WithID(&id)
 

--- a/taikun/resource_taikun_user_test.go
+++ b/taikun/resource_taikun_user_test.go
@@ -1,6 +1,7 @@
 package taikun
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -216,7 +217,7 @@ func testAccCheckTaikunUserDestroy(state *terraform.State) error {
 			continue
 		}
 
-		retryErr := resource.Retry(getReadAfterOpTimeout(false), func() *resource.RetryError {
+		retryErr := resource.RetryContext(context.Background(), getReadAfterOpTimeout(false), func() *resource.RetryError {
 			params := users.NewUsersListParams().WithV(ApiVersion).WithID(&rs.Primary.ID)
 
 			response, err := client.client.Users.UsersList(params, client)

--- a/taikun/resource_taikun_user_test.go
+++ b/taikun/resource_taikun_user_test.go
@@ -88,7 +88,7 @@ func TestAccResourceTaikunUser(t *testing.T) {
 					userDisabled,
 					approvedByPartner,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunUserExists,
 					resource.TestCheckResourceAttr("taikun_user.foo", "user_name", userName),
 					resource.TestCheckResourceAttr("taikun_user.foo", "email", email),
@@ -142,7 +142,7 @@ func TestAccResourceTaikunUserUpdate(t *testing.T) {
 					userDisabled,
 					approvedByPartner,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunUserExists,
 					resource.TestCheckResourceAttr("taikun_user.foo", "user_name", userName),
 					resource.TestCheckResourceAttr("taikun_user.foo", "email", email),
@@ -168,7 +168,7 @@ func TestAccResourceTaikunUserUpdate(t *testing.T) {
 					newUserDisabled,
 					newApprovedByPartner,
 				),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTaikunUserExists,
 					resource.TestCheckResourceAttr("taikun_user.foo", "user_name", newUserName),
 					resource.TestCheckResourceAttr("taikun_user.foo", "email", newEmail),


### PR DESCRIPTION
After a resource is destroyed in a test, retry reading if the resource still exists immediately after deleting it.