### PR TITLE
refactor: split generate read into two functions instead of setting bool flag

### DIFF
--- a/taikun/data_source_taikun_access_profile.go
+++ b/taikun/data_source_taikun_access_profile.go
@@ -25,5 +25,5 @@ func dataSourceTaikunAccessProfile() *schema.Resource {
 func dataSourceTaikunAccessProfileRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunAccessProfileRead(false)(ctx, data, meta)
+	return generateResourceTaikunAccessProfileReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_alerting_profile.go
+++ b/taikun/data_source_taikun_alerting_profile.go
@@ -24,5 +24,5 @@ func dataSourceTaikunAlertingProfile() *schema.Resource {
 
 func dataSourceTaikunAlertingProfileRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
-	return generateResourceTaikunAlertingProfileRead(false)(ctx, data, meta)
+	return generateResourceTaikunAlertingProfileReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_backup_credential.go
+++ b/taikun/data_source_taikun_backup_credential.go
@@ -26,5 +26,5 @@ func dataSourceTaikunBackupCredential() *schema.Resource {
 func dataSourceTaikunBackupCredentialRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunBackupCredentialRead(false)(ctx, data, meta)
+	return generateResourceTaikunBackupCredentialReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_billing_credential.go
+++ b/taikun/data_source_taikun_billing_credential.go
@@ -25,5 +25,5 @@ func dataSourceTaikunBillingCredential() *schema.Resource {
 func dataSourceTaikunBillingCredentialRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunBillingCredentialRead(false)(ctx, data, meta)
+	return generateResourceTaikunBillingCredentialReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_billing_rule.go
+++ b/taikun/data_source_taikun_billing_rule.go
@@ -25,5 +25,5 @@ func dataSourceTaikunBillingRule() *schema.Resource {
 func dataSourceTaikunBillingRuleRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunBillingRuleRead(false)(ctx, data, meta)
+	return generateResourceTaikunBillingRuleReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_cloud_credential_aws.go
+++ b/taikun/data_source_taikun_cloud_credential_aws.go
@@ -26,5 +26,5 @@ func dataSourceTaikunCloudCredentialAWS() *schema.Resource {
 func dataSourceTaikunCloudCredentialAWSRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunCloudCredentialAWSRead(false)(ctx, data, meta)
+	return generateResourceTaikunCloudCredentialAWSReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_cloud_credential_azure.go
+++ b/taikun/data_source_taikun_cloud_credential_azure.go
@@ -26,5 +26,5 @@ func dataSourceTaikunCloudCredentialAzure() *schema.Resource {
 func dataSourceTaikunCloudCredentialAzureRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunCloudCredentialAzureRead(false)(ctx, data, meta)
+	return generateResourceTaikunCloudCredentialAzureReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_cloud_credential_openstack.go
+++ b/taikun/data_source_taikun_cloud_credential_openstack.go
@@ -26,5 +26,5 @@ func dataSourceTaikunCloudCredentialOpenStack() *schema.Resource {
 func dataSourceTaikunCloudCredentialOpenStackRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunCloudCredentialOpenStackRead(false)(ctx, data, meta)
+	return generateResourceTaikunCloudCredentialOpenStackReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_kubeconfig.go
+++ b/taikun/data_source_taikun_kubeconfig.go
@@ -25,5 +25,5 @@ func dataSourceTaikunKubeconfig() *schema.Resource {
 
 func dataSourceTaikunKubeconfigRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
-	return generateResourceTaikunKubeconfigRead(false)(ctx, data, meta)
+	return generateResourceTaikunKubeconfigReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_kubernetes_profile.go
+++ b/taikun/data_source_taikun_kubernetes_profile.go
@@ -25,5 +25,5 @@ func dataSourceTaikunKubernetesProfile() *schema.Resource {
 func dataSourceTaikunKubernetesProfileRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunKubernetesProfileRead(false)(ctx, data, meta)
+	return generateResourceTaikunKubernetesProfileReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_project.go
+++ b/taikun/data_source_taikun_project.go
@@ -25,5 +25,5 @@ func dataSourceTaikunProject() *schema.Resource {
 
 func dataSourceTaikunProjectRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
-	return generateResourceTaikunProjectRead(false)(ctx, data, meta)
+	return generateResourceTaikunProjectReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_showback_credential.go
+++ b/taikun/data_source_taikun_showback_credential.go
@@ -25,5 +25,5 @@ func dataSourceTaikunShowbackCredential() *schema.Resource {
 func dataSourceTaikunShowbackCredentialRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunShowbackCredentialRead(false)(ctx, data, meta)
+	return generateResourceTaikunShowbackCredentialReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_showback_rule.go
+++ b/taikun/data_source_taikun_showback_rule.go
@@ -25,5 +25,5 @@ func dataSourceTaikunShowbackRule() *schema.Resource {
 func dataSourceTaikunShowbackRuleRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunShowbackRuleRead(false)(ctx, data, meta)
+	return generateResourceTaikunShowbackRuleReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_slack_configuration.go
+++ b/taikun/data_source_taikun_slack_configuration.go
@@ -24,5 +24,5 @@ func dataSourceTaikunSlackConfiguration() *schema.Resource {
 
 func dataSourceTaikunSlackConfigurationRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
-	return generateResourceTaikunSlackConfigurationRead(false)(ctx, data, meta)
+	return generateResourceTaikunSlackConfigurationReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/data_source_taikun_user.go
+++ b/taikun/data_source_taikun_user.go
@@ -25,5 +25,5 @@ func dataSourceTaikunUser() *schema.Resource {
 func dataSourceTaikunUserRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("id").(string))
 
-	return generateResourceTaikunUserRead(false)(ctx, data, meta)
+	return generateResourceTaikunUserReadWithoutRetries()(ctx, data, meta)
 }

--- a/taikun/resource_taikun_billing_credential.go
+++ b/taikun/resource_taikun_billing_credential.go
@@ -92,7 +92,7 @@ func resourceTaikunBillingCredential() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Taikun Billing Credential",
 		CreateContext: resourceTaikunBillingCredentialCreate,
-		ReadContext:   generateResourceTaikunBillingCredentialRead(false),
+		ReadContext:   generateResourceTaikunBillingCredentialReadWithoutRetries(),
 		UpdateContext: resourceTaikunBillingCredentialUpdate,
 		DeleteContext: resourceTaikunBillingCredentialDelete,
 		Schema:        resourceTaikunBillingCredentialSchema(),
@@ -139,10 +139,15 @@ func resourceTaikunBillingCredentialCreate(ctx context.Context, data *schema.Res
 		}
 	}
 
-	return readAfterCreateWithRetries(generateResourceTaikunBillingCredentialRead(true), ctx, data, meta)
+	return readAfterCreateWithRetries(generateResourceTaikunBillingCredentialReadWithRetries(), ctx, data, meta)
 }
-
-func generateResourceTaikunBillingCredentialRead(isAfterUpdateOrCreate bool) schema.ReadContextFunc {
+func generateResourceTaikunBillingCredentialReadWithRetries() schema.ReadContextFunc {
+	return generateResourceTaikunBillingCredentialRead(true)
+}
+func generateResourceTaikunBillingCredentialReadWithoutRetries() schema.ReadContextFunc {
+	return generateResourceTaikunBillingCredentialRead(false)
+}
+func generateResourceTaikunBillingCredentialRead(withRetries bool) schema.ReadContextFunc {
 	return func(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		apiClient := meta.(*apiClient)
 		id, err := atoi32(data.Id())
@@ -156,7 +161,7 @@ func generateResourceTaikunBillingCredentialRead(isAfterUpdateOrCreate bool) sch
 			return diag.FromErr(err)
 		}
 		if len(response.Payload.Data) != 1 {
-			if isAfterUpdateOrCreate {
+			if withRetries {
 				data.SetId(i32toa(id))
 				return diag.Errorf(notFoundAfterCreateOrUpdateError)
 			}
@@ -189,7 +194,7 @@ func resourceTaikunBillingCredentialUpdate(ctx context.Context, data *schema.Res
 		}
 	}
 
-	return readAfterUpdateWithRetries(generateResourceTaikunBillingCredentialRead(true), ctx, data, meta)
+	return readAfterUpdateWithRetries(generateResourceTaikunBillingCredentialReadWithRetries(), ctx, data, meta)
 }
 
 func resourceTaikunBillingCredentialDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/taikun/resource_taikun_organization.go
+++ b/taikun/resource_taikun_organization.go
@@ -117,7 +117,7 @@ func resourceTaikunOrganization() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Taikun Organization",
 		CreateContext: resourceTaikunOrganizationCreate,
-		ReadContext:   generateResourceTaikunOrganizationRead(false),
+		ReadContext:   generateResourceTaikunOrganizationReadWithoutRetries(),
 		UpdateContext: resourceTaikunOrganizationUpdate,
 		DeleteContext: resourceTaikunOrganizationDelete,
 		Schema:        resourceTaikunOrganizationSchema(),
@@ -179,10 +179,15 @@ func resourceTaikunOrganizationCreate(ctx context.Context, data *schema.Resource
 		}
 	}
 
-	return readAfterCreateWithRetries(generateResourceTaikunOrganizationRead(true), ctx, data, meta)
+	return readAfterCreateWithRetries(generateResourceTaikunOrganizationReadWithRetries(), ctx, data, meta)
 }
-
-func generateResourceTaikunOrganizationRead(isAfterUpdateOrCreate bool) schema.ReadContextFunc {
+func generateResourceTaikunOrganizationReadWithRetries() schema.ReadContextFunc {
+	return generateResourceTaikunOrganizationRead(true)
+}
+func generateResourceTaikunOrganizationReadWithoutRetries() schema.ReadContextFunc {
+	return generateResourceTaikunOrganizationRead(false)
+}
+func generateResourceTaikunOrganizationRead(withRetries bool) schema.ReadContextFunc {
 	return func(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		apiClient := meta.(*apiClient)
 		id := data.Id()
@@ -194,7 +199,7 @@ func generateResourceTaikunOrganizationRead(isAfterUpdateOrCreate bool) schema.R
 			return diag.FromErr(err)
 		}
 		if len(response.Payload.Data) != 1 {
-			if isAfterUpdateOrCreate {
+			if withRetries {
 				data.SetId(id)
 				return diag.Errorf(notFoundAfterCreateOrUpdateError)
 			}
@@ -244,7 +249,7 @@ func resourceTaikunOrganizationUpdate(ctx context.Context, data *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	return readAfterUpdateWithRetries(generateResourceTaikunOrganizationRead(true), ctx, data, meta)
+	return readAfterUpdateWithRetries(generateResourceTaikunOrganizationReadWithRetries(), ctx, data, meta)
 }
 
 func resourceTaikunOrganizationDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/taikun/resource_taikun_organization.go
+++ b/taikun/resource_taikun_organization.go
@@ -23,7 +23,6 @@ func resourceTaikunOrganizationSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 		},
-		// TODO bound_rules?
 		"city": {
 			Description: "City.",
 			Type:        schema.TypeString,

--- a/taikun/resource_taikun_organization_billing_rule_attachment.go
+++ b/taikun/resource_taikun_organization_billing_rule_attachment.go
@@ -49,7 +49,7 @@ func resourceTaikunOrganizationBillingRuleAttachment() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Taikun Organization - Billing Rule Attachment",
 		CreateContext: resourceTaikunOrganizationBillingRuleAttachmentCreate,
-		ReadContext:   generateResourceTaikunOrganizationBillingRuleAttachmentRead(false),
+		ReadContext:   generateResourceTaikunOrganizationBillingRuleAttachmentReadWithoutRetries(),
 		DeleteContext: resourceTaikunOrganizationBillingRuleAttachmentDelete,
 		Schema:        resourceTaikunOrganizationBillingRuleAttachmentSchema(),
 	}
@@ -87,10 +87,15 @@ func resourceTaikunOrganizationBillingRuleAttachmentCreate(ctx context.Context, 
 	id := fmt.Sprintf("%d/%d", organizationId, billingRuleId)
 	data.SetId(id)
 
-	return readAfterCreateWithRetries(generateResourceTaikunOrganizationBillingRuleAttachmentRead(true), ctx, data, meta)
+	return readAfterCreateWithRetries(generateResourceTaikunOrganizationBillingRuleAttachmentReadWithRetries(), ctx, data, meta)
 }
-
-func generateResourceTaikunOrganizationBillingRuleAttachmentRead(isAfterUpdateOrCreate bool) schema.ReadContextFunc {
+func generateResourceTaikunOrganizationBillingRuleAttachmentReadWithRetries() schema.ReadContextFunc {
+	return generateResourceTaikunOrganizationBillingRuleAttachmentRead(true)
+}
+func generateResourceTaikunOrganizationBillingRuleAttachmentReadWithoutRetries() schema.ReadContextFunc {
+	return generateResourceTaikunOrganizationBillingRuleAttachmentRead(false)
+}
+func generateResourceTaikunOrganizationBillingRuleAttachmentRead(withRetries bool) schema.ReadContextFunc {
 	return func(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		apiClient := meta.(*apiClient)
 
@@ -107,7 +112,7 @@ func generateResourceTaikunOrganizationBillingRuleAttachmentRead(isAfterUpdateOr
 			return diag.FromErr(err)
 		}
 		if len(response.Payload.Data) != 1 {
-			if isAfterUpdateOrCreate {
+			if withRetries {
 				data.SetId(id)
 				return diag.Errorf(notFoundAfterCreateOrUpdateError)
 			}
@@ -135,7 +140,7 @@ func generateResourceTaikunOrganizationBillingRuleAttachmentRead(isAfterUpdateOr
 			}
 		}
 
-		if isAfterUpdateOrCreate {
+		if withRetries {
 			data.SetId(id)
 			return diag.Errorf(notFoundAfterCreateOrUpdateError)
 		}

--- a/taikun/resource_taikun_project.go
+++ b/taikun/resource_taikun_project.go
@@ -480,7 +480,7 @@ func resourceTaikunProjectCreate(ctx context.Context, data *schema.ResourceData,
 	_, quotaRAMIsSet := data.GetOk("quota_ram_size")
 	if quotaCPUIsSet || quotaDiskIsSet || quotaRAMIsSet {
 
-		params := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(projectID) // TODO use /api/v1/projects endpoint?
+		params := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(projectID)
 		response, err := apiClient.client.Servers.ServersDetails(params, apiClient)
 		if err != nil {
 			return diag.FromErr(err)
@@ -533,7 +533,7 @@ func generateResourceTaikunProjectRead(withRetries bool) schema.ReadContextFunc 
 			return diag.FromErr(err)
 		}
 
-		params := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(id32) // TODO use /api/v1/projects endpoint?
+		params := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(id32)
 		response, err := apiClient.client.Servers.ServersDetails(params, apiClient)
 		if err != nil {
 			if withRetries {
@@ -818,7 +818,7 @@ func resourceTaikunProjectDelete(ctx context.Context, data *schema.ResourceData,
 }
 
 func resourceTaikunProjectUnlockIfLocked(projectID int32, apiClient *apiClient) error {
-	readParams := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(projectID) // TODO use /api/v1/projects endpoint?
+	readParams := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(projectID)
 	response, err := apiClient.client.Servers.ServersDetails(readParams, apiClient)
 	if err != nil {
 		return err
@@ -896,7 +896,7 @@ func resourceTaikunProjectUpdateToggleBackup(ctx context.Context, data *schema.R
 					strconv.FormatBool(false),
 				},
 				Refresh: func() (interface{}, string, error) {
-					params := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(projectID) // TODO use /api/v1/projects endpoint?
+					params := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(projectID)
 					response, err := apiClient.client.Servers.ServersDetails(params, apiClient)
 					if err != nil {
 						return 0, "", err
@@ -963,7 +963,6 @@ func resourceTaikunProjectEditQuotas(data *schema.ResourceData, apiClient *apiCl
 	return nil
 }
 
-// TODO change type of DTO if read endpoint is modified
 func flattenTaikunProject(projectDetailsDTO *models.ProjectDetailsForServersDto, serverListDTO []*models.ServerListDto, boundFlavorDTOs []*models.BoundFlavorsForProjectsListDto, projectQuotaDTO *models.ProjectQuotaListDto) map[string]interface{} {
 	flavors := make([]string, len(boundFlavorDTOs))
 	for i, boundFlavorDTO := range boundFlavorDTOs {

--- a/taikun/resource_taikun_showback_credential.go
+++ b/taikun/resource_taikun_showback_credential.go
@@ -87,7 +87,7 @@ func resourceTaikunShowbackCredential() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Taikun Showback Credential",
 		CreateContext: resourceTaikunShowbackCredentialCreate,
-		ReadContext:   generateResourceTaikunShowbackCredentialRead(false),
+		ReadContext:   generateResourceTaikunShowbackCredentialReadWithoutRetries(),
 		UpdateContext: resourceTaikunShowbackCredentialUpdate,
 		DeleteContext: resourceTaikunShowbackCredentialDelete,
 		Schema:        resourceTaikunShowbackCredentialSchema(),
@@ -134,10 +134,15 @@ func resourceTaikunShowbackCredentialCreate(ctx context.Context, data *schema.Re
 		}
 	}
 
-	return readAfterCreateWithRetries(generateResourceTaikunShowbackCredentialRead(true), ctx, data, meta)
+	return readAfterCreateWithRetries(generateResourceTaikunShowbackCredentialReadWithRetries(), ctx, data, meta)
 }
-
-func generateResourceTaikunShowbackCredentialRead(isAfterUpdateOrCreate bool) schema.ReadContextFunc {
+func generateResourceTaikunShowbackCredentialReadWithRetries() schema.ReadContextFunc {
+	return generateResourceTaikunShowbackCredentialRead(true)
+}
+func generateResourceTaikunShowbackCredentialReadWithoutRetries() schema.ReadContextFunc {
+	return generateResourceTaikunShowbackCredentialRead(false)
+}
+func generateResourceTaikunShowbackCredentialRead(withRetries bool) schema.ReadContextFunc {
 	return func(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		apiClient := meta.(*apiClient)
 		id, err := atoi32(data.Id())
@@ -151,7 +156,7 @@ func generateResourceTaikunShowbackCredentialRead(isAfterUpdateOrCreate bool) sc
 			return diag.FromErr(err)
 		}
 		if len(response.Payload.Data) != 1 {
-			if isAfterUpdateOrCreate {
+			if withRetries {
 				data.SetId(i32toa(id))
 				return diag.Errorf(notFoundAfterCreateOrUpdateError)
 			}
@@ -184,7 +189,7 @@ func resourceTaikunShowbackCredentialUpdate(ctx context.Context, data *schema.Re
 		}
 	}
 
-	return readAfterUpdateWithRetries(generateResourceTaikunShowbackCredentialRead(true), ctx, data, meta)
+	return readAfterUpdateWithRetries(generateResourceTaikunShowbackCredentialReadWithRetries(), ctx, data, meta)
 }
 
 func resourceTaikunShowbackCredentialDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/taikun/resource_taikun_showback_rule.go
+++ b/taikun/resource_taikun_showback_rule.go
@@ -135,7 +135,7 @@ func resourceTaikunShowbackRule() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Taikun Showback Rule",
 		CreateContext: resourceTaikunShowbackRuleCreate,
-		ReadContext:   generateResourceTaikunShowbackRuleRead(false),
+		ReadContext:   generateResourceTaikunShowbackRuleReadWithoutRetries(),
 		UpdateContext: resourceTaikunShowbackRuleUpdate,
 		DeleteContext: resourceTaikunShowbackRuleDelete,
 		Schema:        resourceTaikunShowbackRuleSchema(),
@@ -195,10 +195,15 @@ func resourceTaikunShowbackRuleCreate(ctx context.Context, data *schema.Resource
 
 	data.SetId(createResult.Payload.ID)
 
-	return readAfterCreateWithRetries(generateResourceTaikunShowbackRuleRead(true), ctx, data, meta)
+	return readAfterCreateWithRetries(generateResourceTaikunShowbackRuleReadWithRetries(), ctx, data, meta)
 }
-
-func generateResourceTaikunShowbackRuleRead(isAfterUpdateOrCreate bool) schema.ReadContextFunc {
+func generateResourceTaikunShowbackRuleReadWithRetries() schema.ReadContextFunc {
+	return generateResourceTaikunShowbackRuleRead(true)
+}
+func generateResourceTaikunShowbackRuleReadWithoutRetries() schema.ReadContextFunc {
+	return generateResourceTaikunShowbackRuleRead(false)
+}
+func generateResourceTaikunShowbackRuleRead(withRetries bool) schema.ReadContextFunc {
 	return func(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 		apiClient := meta.(*apiClient)
 		id, err := atoi32(data.Id())
@@ -212,7 +217,7 @@ func generateResourceTaikunShowbackRuleRead(isAfterUpdateOrCreate bool) schema.R
 			return diag.FromErr(err)
 		}
 		if len(response.Payload.Data) != 1 {
-			if isAfterUpdateOrCreate {
+			if withRetries {
 				data.SetId(i32toa(id))
 				return diag.Errorf(notFoundAfterCreateOrUpdateError)
 			}
@@ -267,7 +272,7 @@ func resourceTaikunShowbackRuleUpdate(ctx context.Context, data *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	return readAfterUpdateWithRetries(generateResourceTaikunShowbackRuleRead(true), ctx, data, meta)
+	return readAfterUpdateWithRetries(generateResourceTaikunShowbackRuleReadWithRetries(), ctx, data, meta)
 }
 
 func resourceTaikunShowbackRuleDelete(_ context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
`generateResourceTaikunAccessProfileRead(true)` -> `generateResourceTaikunAccessProfileReadWithRetries`
`generateResourceTaikunAccessProfileRead(false)` -> `generateResourceTaikunAccessProfileReadWithoutRetries`