### PR TITLE
chore(sweepers): add different prefixes for taikun's tf and cli tests

### DIFF
--- a/taikun/helper.go
+++ b/taikun/helper.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/mail"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-uuid"
@@ -22,6 +23,21 @@ import (
 )
 
 const testNamePrefix = "tf-acc-test-"
+
+var testNamePrefixes = []string{
+	testNamePrefix, // Terraform provider acceptance tests
+	"tk-cli-test-", // Taikun CLI tests
+	"tk-tf-test-",  // Taikun Terraform tests
+}
+
+func shouldSweep(resourceName string) bool {
+	for _, prefix := range testNamePrefixes {
+		if strings.HasPrefix(resourceName, prefix) {
+			return true
+		}
+	}
+	return false
+}
 
 func init() {
 	rand.Seed(time.Now().UnixNano())

--- a/taikun/resource_taikun_access_profile_test.go
+++ b/taikun/resource_taikun_access_profile_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range accessProfilesList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := access_profiles.NewAccessProfilesDeleteParams().WithV(ApiVersion).WithID(e.ID)
 					_, _, err = apiClient.client.AccessProfiles.AccessProfilesDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_alerting_profile_test.go
+++ b/taikun/resource_taikun_alerting_profile_test.go
@@ -43,7 +43,7 @@ func init() {
 			}
 
 			for _, e := range alertingProfilesList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					body := models.DeleteAlertingProfilesCommand{ID: e.ID}
 					params := alerting_profiles.NewAlertingProfilesDeleteParams().WithV(ApiVersion).WithBody(&body)
 					_, _, err = apiClient.client.AlertingProfiles.AlertingProfilesDelete(params, apiClient)

--- a/taikun/resource_taikun_backup_credential_test.go
+++ b/taikun/resource_taikun_backup_credential_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range backupCredentialsList {
-				if strings.HasPrefix(e.S3Name, testNamePrefix) {
+				if shouldSweep(e.S3Name) {
 					params := s3_credentials.NewS3CredentialsDeleteParams().WithV(ApiVersion).WithID(e.ID)
 					_, _, err = apiClient.client.S3Credentials.S3CredentialsDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_billing_credential_test.go
+++ b/taikun/resource_taikun_billing_credential_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range operationCredentialsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := ops_credentials.NewOpsCredentialsDeleteParams().WithV(ApiVersion).WithID(e.ID)
 					_, _, err = apiClient.client.OpsCredentials.OpsCredentialsDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_billing_rule_test.go
+++ b/taikun/resource_taikun_billing_rule_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -42,7 +41,7 @@ func init() {
 			}
 
 			for _, e := range billingRulesList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := prometheus.NewPrometheusDeleteParams().WithV(ApiVersion).WithID(e.ID)
 					_, err = apiClient.client.Prometheus.PrometheusDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_cloud_credential_aws_test.go
+++ b/taikun/resource_taikun_cloud_credential_aws_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range cloudCredentialsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := cloud_credentials.NewCloudCredentialsDeleteParams().WithV(ApiVersion).WithCloudID(e.ID)
 					_, _, err = apiClient.client.CloudCredentials.CloudCredentialsDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_cloud_credential_azure_test.go
+++ b/taikun/resource_taikun_cloud_credential_azure_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range cloudCredentialsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := cloud_credentials.NewCloudCredentialsDeleteParams().WithV(ApiVersion).WithCloudID(e.ID)
 					_, _, err = apiClient.client.CloudCredentials.CloudCredentialsDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_cloud_credential_openstack_test.go
+++ b/taikun/resource_taikun_cloud_credential_openstack_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range cloudCredentialsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := cloud_credentials.NewCloudCredentialsDeleteParams().WithV(ApiVersion).WithCloudID(e.ID)
 					_, _, err = apiClient.client.CloudCredentials.CloudCredentialsDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_kubeconfig_test.go
+++ b/taikun/resource_taikun_kubeconfig_test.go
@@ -1,8 +1,6 @@
 package taikun
 
 import (
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/itera-io/taikungoclient/client/kube_config"
 	"github.com/itera-io/taikungoclient/models"
@@ -38,7 +36,7 @@ func init() {
 			}
 
 			for _, e := range kubeconfigDTOs {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 
 					body := models.DeleteKubeConfigCommand{
 						ID: e.ID,

--- a/taikun/resource_taikun_kubernetes_profile_test.go
+++ b/taikun/resource_taikun_kubernetes_profile_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -42,7 +41,7 @@ func init() {
 			}
 
 			for _, e := range kubernetesProfilesList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := kubernetes_profiles.NewKubernetesProfilesDeleteParams().WithV(ApiVersion).WithID(e.ID)
 					_, _, err = apiClient.client.KubernetesProfiles.KubernetesProfilesDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_organization_test.go
+++ b/taikun/resource_taikun_organization_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -46,7 +45,7 @@ func init() {
 			}
 
 			for _, e := range organizationsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := organizations.NewOrganizationsDeleteParams().WithV(ApiVersion).WithOrganizationID(e.ID)
 					_, _, err = apiClient.client.Organizations.OrganizationsDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_policy_profile_test.go
+++ b/taikun/resource_taikun_policy_profile_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/itera-io/taikungoclient/client/opa_profiles"
@@ -43,7 +42,7 @@ func init() {
 			}
 
 			for _, e := range PolicyProfilesList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := opa_profiles.NewOpaProfilesDeleteParams().WithV(ApiVersion).WithBody(&models.DeleteOpaProfileCommand{ID: e.ID})
 					_, err = apiClient.client.OpaProfiles.OpaProfilesDelete(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_project_test.go
+++ b/taikun/resource_taikun_project_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -45,7 +44,7 @@ func init() {
 			}
 
 			for _, e := range projectList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 
 					readParams := servers.NewServersDetailsParams().WithV(ApiVersion).WithProjectID(e.ID)
 					response, err := apiClient.client.Servers.ServersDetails(readParams, apiClient)

--- a/taikun/resource_taikun_showback_credential_test.go
+++ b/taikun/resource_taikun_showback_credential_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -42,7 +41,7 @@ func init() {
 			}
 
 			for _, e := range showbackCredentialsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := showback.NewShowbackDeleteShowbackCredentialParams().WithV(ApiVersion).WithBody(&models.DeleteShowbackCredentialCommand{ID: e.ID})
 					_, err = apiClient.client.Showback.ShowbackDeleteShowbackCredential(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_showback_rule_test.go
+++ b/taikun/resource_taikun_showback_rule_test.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/itera-io/taikungoclient/client/showback"
@@ -46,7 +45,7 @@ func init() {
 			}
 
 			for _, e := range showbackRulesList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					params := showback.NewShowbackDeleteRuleParams().WithV(ApiVersion).WithBody(&models.DeleteShowbackRuleCommand{ID: e.ID})
 					_, err = apiClient.client.Showback.ShowbackDeleteRule(params, apiClient)
 					if err != nil {

--- a/taikun/resource_taikun_slack_configuration_test.go
+++ b/taikun/resource_taikun_slack_configuration_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -44,7 +43,7 @@ func init() {
 			}
 
 			for _, e := range slackConfigurationsList {
-				if strings.HasPrefix(e.Name, testNamePrefix) {
+				if shouldSweep(e.Name) {
 					body := models.DeleteSlackConfigurationCommand{ID: e.ID}
 					params := slack.NewSlackDeleteParams().WithV(ApiVersion).WithBody(&body)
 					_, _, err = apiClient.client.Slack.SlackDelete(params, apiClient)

--- a/taikun/resource_taikun_user_test.go
+++ b/taikun/resource_taikun_user_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -41,7 +40,7 @@ func init() {
 			}
 
 			for _, e := range userList {
-				if strings.HasPrefix(e.Username, testNamePrefix) {
+				if shouldSweep(e.Username) {
 					params := users.NewUsersDeleteParams().WithV(ApiVersion).WithID(e.ID)
 					_, _, err = apiClient.client.Users.UsersDelete(params, apiClient)
 					if err != nil {


### PR DESCRIPTION
Adds two new resource name prefixes to sweep:
- `tk-cli-test-` for resources created by Taikun's CLI tests
- `tk-tf-test-` for resources created by Taikun's Terraform tests