### PR TITLE
feat(kubeconfig): add 'content' attribute

### DIFF
--- a/docs/data-sources/kubeconfig.md
+++ b/docs/data-sources/kubeconfig.md
@@ -28,6 +28,7 @@ data "taikun_kubeconfig" "foo" {
 ### Read-Only
 
 - **access_scope** (String) Who can use the kubeconfig: `personal` (only you), `managers` (managers only) or `all` (all users with access to this project).
+- **content** (String, Sensitive) Content of the kubeconfig.
 - **name** (String) The kubeconfig's name.
 - **project_id** (String) ID of the kubeconfig's project.
 - **project_name** (String) Name of the kubeconfig's project.

--- a/docs/data-sources/kubeconfig.md
+++ b/docs/data-sources/kubeconfig.md
@@ -28,7 +28,7 @@ data "taikun_kubeconfig" "foo" {
 ### Read-Only
 
 - **access_scope** (String) Who can use the kubeconfig: `personal` (only you), `managers` (managers only) or `all` (all users with access to this project).
-- **content** (String, Sensitive) Content of the kubeconfig.
+- **content** (String, Sensitive) Content of the kubeconfig's YAML file.
 - **name** (String) The kubeconfig's name.
 - **project_id** (String) ID of the kubeconfig's project.
 - **project_name** (String) Name of the kubeconfig's project.

--- a/docs/data-sources/kubeconfigs.md
+++ b/docs/data-sources/kubeconfigs.md
@@ -35,6 +35,7 @@ data "taikun_kubeconfigs" "foo" {
 Read-Only:
 
 - **access_scope** (String)
+- **content** (String)
 - **id** (String)
 - **name** (String)
 - **project_id** (String)

--- a/docs/resources/kubeconfig.md
+++ b/docs/resources/kubeconfig.md
@@ -34,7 +34,7 @@ resource "taikun_kubeconfig" "foo" {
 
 ### Read-Only
 
-- **content** (String, Sensitive) Content of the kubeconfig.
+- **content** (String, Sensitive) Content of the kubeconfig's YAML file.
 - **id** (String) The kubeconfig's ID.
 - **project_name** (String) Name of the kubeconfig's project.
 - **user_id** (String) ID of the kubeconfig's user, if the kubeconfig is personal.

--- a/docs/resources/kubeconfig.md
+++ b/docs/resources/kubeconfig.md
@@ -34,6 +34,7 @@ resource "taikun_kubeconfig" "foo" {
 
 ### Read-Only
 
+- **content** (String, Sensitive) Content of the kubeconfig.
 - **id** (String) The kubeconfig's ID.
 - **project_name** (String) Name of the kubeconfig's project.
 - **user_id** (String) ID of the kubeconfig's user, if the kubeconfig is personal.

--- a/docs/resources/kubeconfig.md
+++ b/docs/resources/kubeconfig.md
@@ -16,9 +16,15 @@ Taikun Kubeconfig
 resource "taikun_kubeconfig" "foo" {
   project_id = "1234"
 
-  name         = "foo"
-  role         = "edit"
-  access_scope = "managers"
+  name         = "all-can-view"
+  role         = "view"
+  access_scope = "all"
+}
+
+resource "local_file" "kubeconfig-foo" {
+  content         = taikun_kubeconfig.foo.content
+  filename        = "${path.module}/${taikun_kubeconfig.foo.project_id}-kubeconfig.yaml"
+  file_permission = "0644"
 }
 ```
 

--- a/examples/resources/taikun_kubeconfig/resource.tf
+++ b/examples/resources/taikun_kubeconfig/resource.tf
@@ -1,7 +1,13 @@
 resource "taikun_kubeconfig" "foo" {
   project_id = "1234"
 
-  name         = "foo"
-  role         = "edit"
-  access_scope = "managers"
+  name         = "all-can-view"
+  role         = "view"
+  access_scope = "all"
+}
+
+resource "local_file" "kubeconfig-foo" {
+  content         = taikun_kubeconfig.foo.content
+  filename        = "${path.module}/${taikun_kubeconfig.foo.project_id}-kubeconfig.yaml"
+  file_permission = "0644"
 }

--- a/taikun/data_source_taikun_kubeconfigs.go
+++ b/taikun/data_source_taikun_kubeconfigs.go
@@ -63,14 +63,11 @@ func dataSourceTaikunKubeconfigsRead(_ context.Context, d *schema.ResourceData, 
 
 	kubeconfigs := make([]map[string]interface{}, len(kubeconfigDTOs))
 	for i, kubeconfigDTO := range kubeconfigDTOs {
-		kubeconfigContent, err := resourceTaikunKubeconfigGetContent(
+		kubeconfigContent := resourceTaikunKubeconfigGetContent(
 			kubeconfigDTO.ProjectID,
 			kubeconfigDTO.ID,
 			apiClient,
 		)
-		if err != nil {
-			return diag.FromErr(err)
-		}
 		kubeconfigs[i] = flattenTaikunKubeconfig(kubeconfigDTO, kubeconfigContent)
 	}
 

--- a/taikun/data_source_taikun_kubeconfigs.go
+++ b/taikun/data_source_taikun_kubeconfigs.go
@@ -63,7 +63,15 @@ func dataSourceTaikunKubeconfigsRead(_ context.Context, d *schema.ResourceData, 
 
 	kubeconfigs := make([]map[string]interface{}, len(kubeconfigDTOs))
 	for i, kubeconfigDTO := range kubeconfigDTOs {
-		kubeconfigs[i] = flattenTaikunKubeconfig(kubeconfigDTO)
+		kubeconfigContent, err := resourceTaikunKubeconfigGetContent(
+			kubeconfigDTO.ProjectID,
+			kubeconfigDTO.ID,
+			apiClient,
+		)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		kubeconfigs[i] = flattenTaikunKubeconfig(kubeconfigDTO, kubeconfigContent)
 	}
 
 	if err := d.Set("kubeconfigs", kubeconfigs); err != nil {

--- a/taikun/resource_taikun_kubeconfig.go
+++ b/taikun/resource_taikun_kubeconfig.go
@@ -151,14 +151,11 @@ func generateResourceTaikunKubeconfigRead(withRetries bool) schema.ReadContextFu
 		}
 
 		kubeconfigDTO := response.Payload.Data[0]
-		kubeconfigContent, err := resourceTaikunKubeconfigGetContent(
+		kubeconfigContent := resourceTaikunKubeconfigGetContent(
 			kubeconfigDTO.ProjectID,
 			kubeconfigDTO.ID,
 			apiClient,
 		)
-		if err != nil {
-			return diag.FromErr(err)
-		}
 		if err := setResourceDataFromMap(d, flattenTaikunKubeconfig(kubeconfigDTO, kubeconfigContent)); err != nil {
 			return diag.FromErr(err)
 		}
@@ -209,7 +206,7 @@ func flattenTaikunKubeconfig(kubeconfigDTO *models.KubeConfigForUserDto, kubecon
 	return kubeconfigMap
 }
 
-func resourceTaikunKubeconfigGetContent(projectID int32, kubeconfigID int32, apiClient *apiClient) (string, error) {
+func resourceTaikunKubeconfigGetContent(projectID int32, kubeconfigID int32, apiClient *apiClient) string {
 
 	body := models.DownloadKubeConfigCommand{
 		ProjectID: projectID,
@@ -221,8 +218,8 @@ func resourceTaikunKubeconfigGetContent(projectID int32, kubeconfigID int32, api
 
 	response, err := apiClient.client.KubeConfig.KubeConfigDownload(params, apiClient)
 	if err != nil {
-		return "", err
+		return "Failed to retrieve content of kubeconfig"
 	}
 
-	return response.Payload.(string), nil
+	return response.Payload.(string)
 }

--- a/taikun/resource_taikun_kubeconfig.go
+++ b/taikun/resource_taikun_kubeconfig.go
@@ -24,7 +24,7 @@ func resourceTaikunKubeconfigSchema() map[string]*schema.Schema {
 			}, false),
 		},
 		"content": {
-			Description: "Content of the kubeconfig.",
+			Description: "Content of the kubeconfig's YAML file.",
 			Type:        schema.TypeString,
 			Sensitive:   true,
 			Computed:    true,

--- a/taikun/resource_taikun_kubeconfig.go
+++ b/taikun/resource_taikun_kubeconfig.go
@@ -23,6 +23,12 @@ func resourceTaikunKubeconfigSchema() map[string]*schema.Schema {
 				"personal",
 			}, false),
 		},
+		"content": {
+			Description: "Content of the kubeconfig.",
+			Type:        schema.TypeString,
+			Sensitive:   true,
+			Computed:    true,
+		},
 		"id": {
 			Description: "The kubeconfig's ID.",
 			Type:        schema.TypeString,
@@ -145,7 +151,15 @@ func generateResourceTaikunKubeconfigRead(withRetries bool) schema.ReadContextFu
 		}
 
 		kubeconfigDTO := response.Payload.Data[0]
-		if err := setResourceDataFromMap(d, flattenTaikunKubeconfig(kubeconfigDTO)); err != nil {
+		kubeconfigContent, err := resourceTaikunKubeconfigGetContent(
+			kubeconfigDTO.ProjectID,
+			kubeconfigDTO.ID,
+			apiClient,
+		)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := setResourceDataFromMap(d, flattenTaikunKubeconfig(kubeconfigDTO, kubeconfigContent)); err != nil {
 			return diag.FromErr(err)
 		}
 
@@ -174,8 +188,9 @@ func resourceTaikunKubeconfigDelete(_ context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func flattenTaikunKubeconfig(kubeconfigDTO *models.KubeConfigForUserDto) map[string]interface{} {
+func flattenTaikunKubeconfig(kubeconfigDTO *models.KubeConfigForUserDto, kubeconfigContent string) map[string]interface{} {
 	kubeconfigMap := map[string]interface{}{
+		"content":      kubeconfigContent,
 		"id":           i32toa(kubeconfigDTO.ID),
 		"name":         kubeconfigDTO.ServiceAccountName,
 		"project_id":   i32toa(kubeconfigDTO.ProjectID),
@@ -192,4 +207,22 @@ func flattenTaikunKubeconfig(kubeconfigDTO *models.KubeConfigForUserDto) map[str
 		kubeconfigMap["access_scope"] = "personal"
 	}
 	return kubeconfigMap
+}
+
+func resourceTaikunKubeconfigGetContent(projectID int32, kubeconfigID int32, apiClient *apiClient) (string, error) {
+
+	body := models.DownloadKubeConfigCommand{
+		ProjectID: projectID,
+		ID:        kubeconfigID,
+	}
+
+	params := kube_config.NewKubeConfigDownloadParams().WithV(ApiVersion)
+	params = params.WithBody(&body)
+
+	response, err := apiClient.client.KubeConfig.KubeConfigDownload(params, apiClient)
+	if err != nil {
+		return "", err
+	}
+
+	return response.Payload.(string), nil
 }

--- a/taikun/resource_taikun_project_test.go
+++ b/taikun/resource_taikun_project_test.go
@@ -1053,6 +1053,10 @@ func TestAccResourceTaikunProjectMinimal(t *testing.T) {
 					resource.TestCheckResourceAttr("taikun_project.foo", "server_kubeworker.#", "1"),
 					resource.TestCheckResourceAttr("taikun_project.foo", "server_kubemaster.#", "1"),
 					resource.TestCheckResourceAttr("data.taikun_kubeconfigs.foo", "kubeconfigs.#", "4"),
+					resource.TestCheckResourceAttrSet("taikun_kubeconfig.view", "content"),
+					resource.TestCheckResourceAttrSet("taikun_kubeconfig.edit", "content"),
+					resource.TestCheckResourceAttrSet("taikun_kubeconfig.admin", "content"),
+					resource.TestCheckResourceAttrSet("taikun_kubeconfig.cluster_admin", "content"),
 				),
 			},
 			{


### PR DESCRIPTION
Adds a `content` attribute to the kubeconfig schema.
This attribute holds the content of the kubeconfig's YAML file.