### PR TITLE
feat(project): add kubernetes-version attribute

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -36,6 +36,7 @@ data "taikun_project" "foo" {
 - **flavors** (Set of String) List of flavors bound to the project.
 - **images** (Set of String) List of images bound to the project.
 - **kubernetes_profile_id** (String) ID of the project's Kubernetes profile. Defaults to the default Kubernetes profile of the project's organization.
+- **kubernetes_version** (String) Kubernetes version.
 - **lock** (Boolean) Indicates whether to lock the project.
 - **monitoring** (Boolean) Kubernetes cluster monitoring.
 - **name** (String) Project name.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -85,6 +85,16 @@ resource "taikun_project" "foobar" {
   auto_upgrade    = true
   monitoring      = true
 
+  # If setting the kubernetes_version, be sure to use the meta-argument
+  # ignore_changes to ignore futures changes in case of kubernetes upgrade
+  # https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes
+  kubernetes_version = "v1.21.5"
+  lifecycle {
+    ignore_changes = [
+      kubernetes_version,
+    ]
+  }
+
   quota_cpu_units = 64
   quota_disk_size = 1024
   quota_ram_size  = 256
@@ -159,6 +169,7 @@ resource "taikun_project" "foobar" {
 - **flavors** (Set of String) List of flavors bound to the project.
 - **images** (Set of String) List of images bound to the project.
 - **kubernetes_profile_id** (String) ID of the project's Kubernetes profile. Defaults to the default Kubernetes profile of the project's organization.
+- **kubernetes_version** (String) Kubernetes version at project creation. Use the meta-argument `ignore_changes` to ignore future upgrades.
 - **lock** (Boolean) Indicates whether to lock the project. Defaults to `false`.
 - **monitoring** (Boolean) Kubernetes cluster monitoring. Defaults to `false`.
 - **organization_id** (String) ID of the organization which owns the project.

--- a/examples/resources/taikun_project/resource.tf
+++ b/examples/resources/taikun_project/resource.tf
@@ -52,6 +52,16 @@ resource "taikun_project" "foobar" {
   quota_disk_size = 1024
   quota_ram_size  = 256
 
+  # If setting the kubernetes_version, be sure to use the meta-argument
+  # ignore_changes to ignore futures changes in case of kubernetes upgrade
+  # https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changes
+  kubernetes_version = "v1.21.5"
+  lifecycle {
+    ignore_changes = [
+      kubernetes_version,
+    ]
+  }
+
   flavors = local.flavors
   images  = local.images
 

--- a/taikun/resource_taikun_project.go
+++ b/taikun/resource_taikun_project.go
@@ -118,7 +118,7 @@ func resourceTaikunProjectSchema() map[string]*schema.Schema {
 			ForceNew:         true,
 		},
 		"kubernetes_version": {
-			Description: "Kubernetes Version.",
+			Description: "Kubernetes Version at project creation. Use the meta-argument `ignore_changes` to ignore future upgrades.",
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,

--- a/taikun/resource_taikun_project_test.go
+++ b/taikun/resource_taikun_project_test.go
@@ -332,6 +332,45 @@ func TestAccResourceTaikunProjectDetachAlertingProfile(t *testing.T) {
 	})
 }
 
+const testAccResourceTaikunProjectKubernetesVersionConfig = `
+resource "taikun_cloud_credential_aws" "foo" {
+  name = "%s"
+  availability_zone = "%s"
+}
+resource "taikun_project" "foo" {
+  name = "%s"
+  cloud_credential_id = resource.taikun_cloud_credential_aws.foo.id
+  auto_upgrade = false
+  kubernetes_version = "%s"
+}
+`
+
+func TestAccResourceTaikunProjectKubernetesVersion(t *testing.T) {
+	cloudCredentialName := randomTestName()
+	projectName := shortRandomTestName()
+	kubernetesVersion := "v1.21.6"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckAWS(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckTaikunProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccResourceTaikunProjectKubernetesVersionConfig,
+					cloudCredentialName,
+					os.Getenv("AWS_AVAILABILITY_ZONE"),
+					projectName,
+					kubernetesVersion,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTaikunProjectExists,
+					resource.TestCheckResourceAttr("taikun_project.foo", "kubernetes_version", kubernetesVersion),
+				),
+			},
+		},
+	})
+}
+
 const testAccResourceTaikunProjectQuotaConfig = `
 resource "taikun_cloud_credential_aws" "foo" {
   name = "%s"


### PR DESCRIPTION
Adds a `kubernetes_version` attribute to the project schema in order to manually set the Kuberntes version when the project is created.