### PR TITLE
Hotfix/release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6.1.0
-        env:
+        with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }} # Hasicorp ghaction is deprecated https://github.com/hashicorp/ghaction-import-gpg
           passphrase: ${{ secrets.PASSPHRASE }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,10 +37,12 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
-    cmd: gpg2
+    cmd: gpg
     args:
       # if you are using this in a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
+      - "--pinentry-mode"
+      - "loopback"
       - "--batch"
       - "-u"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,11 +37,12 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
+    cmd: gpg2
     args:
       # if you are using this in a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--local-user"
+      - "-u"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"
       - "${signature}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,14 +37,11 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
-    cmd: gpg
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
-      - "--pinentry-mode"
-      - "loopback"
       - "--batch"
-      - "-u"
+      - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"
       - "${signature}"


### PR DESCRIPTION
- Typo in sign action. Changing "env" to "with".
- GPG Private Key was broken (most likely expired) and inaccesible.
- GoReleaser upgrade from deprecated "release --rm-dist" to --clean