### PR TITLE
Hotfix/none case destroy case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.1
-	github.com/itera-io/taikungoclient v0.0.0-20250603160123-a19af24c9366
+	github.com/itera-io/taikungoclient v0.0.0-20250820000335-de42f0d3576f
 	github.com/robfig/cron/v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
-github.com/itera-io/taikungoclient v0.0.0-20250603160123-a19af24c9366 h1:b60E3vq1vbwecNQYrEAUpUqGS520x67sAbJVgISM4A0=
-github.com/itera-io/taikungoclient v0.0.0-20250603160123-a19af24c9366/go.mod h1:VEIUQxLg9qNq20j4KELD2XBKak/M/d1OEdEaaCI0olo=
+github.com/itera-io/taikungoclient v0.0.0-20250820000335-de42f0d3576f h1:Rh4khZIlveideUWap6c45PJkmQxwmn49EKpxXlBq+P4=
+github.com/itera-io/taikungoclient v0.0.0-20250820000335-de42f0d3576f/go.mod h1:VEIUQxLg9qNq20j4KELD2XBKak/M/d1OEdEaaCI0olo=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/taikun/app_instance/resource_taikun_app_instance.go
+++ b/taikun/app_instance/resource_taikun_app_instance.go
@@ -219,7 +219,7 @@ func generateResourceTaikunAppInstanceRead(withRetries bool) schema.ReadContextF
 
 		// Application was found in Failed state.
 		// Delete application and create it again.
-		if data.GetStatus() == tkcore.EINSTANCESTATUS_FAILURE {
+		if data.GetStatus() == tkcore.EINSTANCESTATUS_FAILURE || data.GetStatus() == tkcore.EINSTANCESTATUS_NONE {
 			err = d.Set("status", "Failed")
 			if err != nil {
 				return diag.FromErr(err)

--- a/taikun/catalog_project_binding/resource_taikun_catalog_project_binding.go
+++ b/taikun/catalog_project_binding/resource_taikun_catalog_project_binding.go
@@ -117,10 +117,12 @@ func resourceTaikunCatalogProjectBindingDelete(ctx context.Context, d *schema.Re
 	// If not already, unbind the project from the catalog
 	if catalogHasProjectBound {
 		body := []int32{projectId}
-		response, err := apiClient.Client.CatalogAPI.CatalogDeleteProject(context.TODO(), foundCatalog.GetId()).RequestBody(body).Execute()
-		if err != nil {
-			return diag.FromErr(tk.CreateError(response, err))
-		}
+		//response, err := apiClient.Client.CatalogAPI.CatalogDeleteProject(context.TODO(), foundCatalog.GetId()).RequestBody(body).Execute()
+		//if err != nil {
+		//	return diag.FromErr(tk.CreateError(response, err))
+		//}
+		// If you destroy the binding, Terraform will try to unbind, but ignores if the unbind fails. This is useful in case there are other apps present in the project, but not in terraform state.
+		apiClient.Client.CatalogAPI.CatalogDeleteProject(context.TODO(), foundCatalog.GetId()).RequestBody(body).Execute()
 	}
 
 	return nil

--- a/taikun/catalog_project_binding/resource_taikun_catalog_project_binding.go
+++ b/taikun/catalog_project_binding/resource_taikun_catalog_project_binding.go
@@ -122,7 +122,7 @@ func resourceTaikunCatalogProjectBindingDelete(ctx context.Context, d *schema.Re
 		//	return diag.FromErr(tk.CreateError(response, err))
 		//}
 		// If you destroy the binding, Terraform will try to unbind, but ignores if the unbind fails. This is useful in case there are other apps present in the project, but not in terraform state.
-		apiClient.Client.CatalogAPI.CatalogDeleteProject(context.TODO(), foundCatalog.GetId()).RequestBody(body).Execute()
+		_, _ = apiClient.Client.CatalogAPI.CatalogDeleteProject(context.TODO(), foundCatalog.GetId()).RequestBody(body).Execute()
 	}
 
 	return nil

--- a/taikun/project/resource_taikun_project.go
+++ b/taikun/project/resource_taikun_project.go
@@ -3,13 +3,14 @@ package project
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	tk "github.com/itera-io/taikungoclient"
 	tkcore "github.com/itera-io/taikungoclient/client"
 	"github.com/itera-io/terraform-provider-taikun/taikun/utils"
-	"net/http"
-	"regexp"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -882,7 +883,7 @@ func resourceTaikunProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 					serverCreateBody := tkcore.ServerForCreateDto{}
 					serverCreateBody.SetCount(1)
-					serverCreateBody.SetDiskSize(utils.GibiByteToByte(kubeWorkerMap["disk_size"].(int)))
+					serverCreateBody.SetDiskSize(utils.GibiByteToByteInt64(kubeWorkerMap["disk_size"].(int)))
 					serverCreateBody.SetFlavor(kubeWorkerMap["flavor"].(string))
 					serverCreateBody.SetKubernetesNodeLabels(resourceTaikunProjectServerKubernetesLabels(kubeWorkerMap))
 					serverCreateBody.SetName(kubeWorkerMap["name"].(string))

--- a/taikun/project/resource_taikun_project_k8s.go
+++ b/taikun/project/resource_taikun_project_k8s.go
@@ -3,13 +3,14 @@ package project
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	tk "github.com/itera-io/taikungoclient"
 	tkcore "github.com/itera-io/taikungoclient/client"
 	"github.com/itera-io/terraform-provider-taikun/taikun/utils"
-	"regexp"
-	"strconv"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -173,7 +174,7 @@ func resourceTaikunProjectSetServers(d *schema.ResourceData, apiClient *tk.Clien
 	bastion := bastions.(*schema.Set).List()[0].(map[string]interface{})
 	serverCreateBody := tkcore.ServerForCreateDto{}
 	serverCreateBody.SetCount(1)
-	serverCreateBody.SetDiskSize(utils.GibiByteToByte(bastion["disk_size"].(int)))
+	serverCreateBody.SetDiskSize(utils.GibiByteToByteInt64(bastion["disk_size"].(int)))
 	serverCreateBody.SetFlavor(bastion["flavor"].(string))
 	serverCreateBody.SetName(bastion["name"].(string))
 	serverCreateBody.SetAvailabilityZone(bastion["zone"].(string))
@@ -200,7 +201,7 @@ func resourceTaikunProjectSetServers(d *schema.ResourceData, apiClient *tk.Clien
 		kubeMasterMap := kubeMaster.(map[string]interface{})
 		serverCreateBody = tkcore.ServerForCreateDto{}
 		serverCreateBody.SetCount(1)
-		serverCreateBody.SetDiskSize(utils.GibiByteToByte(kubeMasterMap["disk_size"].(int)))
+		serverCreateBody.SetDiskSize(utils.GibiByteToByteInt64(kubeMasterMap["disk_size"].(int)))
 		serverCreateBody.SetFlavor(kubeMasterMap["flavor"].(string))
 		serverCreateBody.SetKubernetesNodeLabels(resourceTaikunProjectServerKubernetesLabels(kubeMasterMap))
 		serverCreateBody.SetName(kubeMasterMap["name"].(string))
@@ -229,7 +230,7 @@ func resourceTaikunProjectSetServers(d *schema.ResourceData, apiClient *tk.Clien
 	for _, kubeWorker := range kubeWorkersList {
 		kubeWorkerMap := kubeWorker.(map[string]interface{})
 		serverCreateBody.SetCount(1)
-		serverCreateBody.SetDiskSize(utils.GibiByteToByte(kubeWorkerMap["disk_size"].(int)))
+		serverCreateBody.SetDiskSize(utils.GibiByteToByteInt64(kubeWorkerMap["disk_size"].(int)))
 		serverCreateBody.SetFlavor(kubeWorkerMap["flavor"].(string))
 		//serverCreateBody.SetKubernetesNodeLabels(resourceTaikunProjectServerKubernetesLabels(kubeWorkerMap))
 		serverCreateBody.SetName(kubeWorkerMap["name"].(string))

--- a/taikun/utils/helper.go
+++ b/taikun/utils/helper.go
@@ -3,15 +3,16 @@ package utils
 import (
 	"context"
 	"fmt"
-	tk "github.com/itera-io/taikungoclient"
-	tkcore "github.com/itera-io/taikungoclient/client"
-	tkshowback "github.com/itera-io/taikungoclient/showbackclient"
 	"math/rand"
 	"net/mail"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	tk "github.com/itera-io/taikungoclient"
+	tkcore "github.com/itera-io/taikungoclient/client"
+	tkshowback "github.com/itera-io/taikungoclient/showbackclient"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/robfig/cron/v3"
@@ -54,6 +55,10 @@ func I32toa(x int32) string {
 
 func GibiByteToByte(gibiBytes int) float64 {
 	return float64(1073741824) * float64(gibiBytes)
+}
+
+func GibiByteToByteInt64(gibiBytes int) int64 {
+	return int64(1073741824) * int64(gibiBytes)
 }
 
 func ByteToGibiByte(x float64) int {

--- a/templates/resources/catalog_project_binding.md.tmpl
+++ b/templates/resources/catalog_project_binding.md.tmpl
@@ -17,5 +17,6 @@ description: |- {{ .Description | plainmarkdown | trimspace | prefixlines "  " }
 {{tffile "examples/resources/taikun_catalog_project_binding/resource.tf"}}
 
 Take a look at the **quickstart template** that deploys a new k8s cluster, a catalog and an app instance - available in the [quickstart examples](https://github.com/itera-io/terraform-provider-taikun/tree/dev/examples/quickstart-templates) folder.
+If you destroy the binding, Terraform will try to unbind, but ignores if the unbind fails. This is useful in case there are other apps present in the project, but not in terraform state.
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
hotfix: If you destroy the binding, Terraform will try to unbind, but ignores if the unbind fails. This is useful in case there are other apps present in the project, but not in terraform state.

hotfix: Instances in None status are treated as failed apps - want to be recreated.

hotfix: update to latest go client generate from prod, modified ahandling of changed disk size dto (float64 > int64)